### PR TITLE
쏙머니 내역 추가 기능 구현

### DIFF
--- a/src/main/java/com/example/ssauc/user/cash/controller/CashController.java
+++ b/src/main/java/com/example/ssauc/user/cash/controller/CashController.java
@@ -13,6 +13,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import java.util.List;
 
 @Controller
@@ -28,20 +32,36 @@ public class CashController {
                            @RequestParam(value = "endDate", required = false) String endDateStr,
                            HttpSession session,
                            Model model) {
+
         Users user = (Users) session.getAttribute("user");
         if (user == null) {
             return "redirect:/login";
         }
         model.addAttribute("filter", filter);
 
+        LocalDateTime startDate = null;
+        LocalDateTime endDate = null;
+        if(startDateStr != null && !startDateStr.isEmpty() && endDateStr != null && !endDateStr.isEmpty()){
+            // 변환 예시: 시작일은 00:00, 종료일은 23:59:59로 설정
+            startDate = LocalDate.parse(startDateStr).atStartOfDay();
+            endDate = LocalDate.parse(endDateStr).atTime(23, 59, 59);
+        }
+
         if ("charge".equals(filter)) {
-            List<ChargeDto> chargeList = cashService.getChargesByUser(user);
+            // 날짜 필터가 있는 경우와 없는 경우를 분기해서 처리
+            List<ChargeDto> chargeList = (startDate != null && endDate != null)
+                    ? cashService.getChargesByUser(user, startDate, endDate)
+                    : cashService.getChargesByUser(user);
             model.addAttribute("chargeList", chargeList);
         } else if ("withdraw".equals(filter)) {
-            List<WithdrawDto> withdrawList = cashService.getWithdrawsByUser(user);
+            List<WithdrawDto> withdrawList = (startDate != null && endDate != null)
+                    ? cashService.getWithdrawsByUser(user, startDate, endDate)
+                    : cashService.getWithdrawsByUser(user);
             model.addAttribute("withdrawList", withdrawList);
         } else if ("calculate".equals(filter)) {
-            List<CalculateDto> calculateList = cashService.getCalculateByUser(user);
+            List<CalculateDto> calculateList = (startDate != null && endDate != null)
+                    ? cashService.getCalculateByUser(user, startDate, endDate)
+                    : cashService.getCalculateByUser(user);
             model.addAttribute("calculateList", calculateList);
         }
 

--- a/src/main/java/com/example/ssauc/user/cash/dto/CalculateDto.java
+++ b/src/main/java/com/example/ssauc/user/cash/dto/CalculateDto.java
@@ -11,7 +11,7 @@ import lombok.*;
 public class CalculateDto {
     private Long orderId;
     private String paymentAmount;   // "+" 또는 "-" 접두어와 total_price
-    private String paymentMethod;   // Payment.payment_method (주문 당 1건의 결제 가정)
+    private String productName;     // orders에서 가져온 상품 이름
     private LocalDateTime paymentTime;  // 판매자: orders.completedDate, 구매자: payment.paymentDate
     private String orderStatus;     // orders.order_status
 }

--- a/src/main/java/com/example/ssauc/user/cash/repository/ChargeRepository.java
+++ b/src/main/java/com/example/ssauc/user/cash/repository/ChargeRepository.java
@@ -2,6 +2,8 @@ package com.example.ssauc.user.cash.repository;
 
 import com.example.ssauc.user.cash.entity.Charge;
 import com.example.ssauc.user.login.entity.Users;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
@@ -10,4 +12,7 @@ import java.util.List;
 public interface ChargeRepository extends JpaRepository<Charge, Long> {
     List<Charge> findByUser(Users user);
     List<Charge> findByUserAndCreatedAtBetween(Users user, LocalDateTime start, LocalDateTime end);
+    // 페이징 처리 메서드 추가
+    Page<Charge> findByUser(Users user, Pageable pageable);
+    Page<Charge> findByUserAndCreatedAtBetween(Users user, LocalDateTime start, LocalDateTime end, Pageable pageable);
 }

--- a/src/main/java/com/example/ssauc/user/cash/repository/ChargeRepository.java
+++ b/src/main/java/com/example/ssauc/user/cash/repository/ChargeRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 
 public interface ChargeRepository extends JpaRepository<Charge, Long> {
     List<Charge> findByUser(Users user);
-
+    List<Charge> findByUserAndCreatedAtBetween(Users user, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/example/ssauc/user/cash/repository/WithdrawRepository.java
+++ b/src/main/java/com/example/ssauc/user/cash/repository/WithdrawRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 
 public interface WithdrawRepository extends JpaRepository<Withdraw, Long> {
     List<Withdraw> findByUser(Users user);
-
+    List<Withdraw> findByUserAndWithdrawAtBetween(Users user, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/example/ssauc/user/cash/repository/WithdrawRepository.java
+++ b/src/main/java/com/example/ssauc/user/cash/repository/WithdrawRepository.java
@@ -2,6 +2,8 @@ package com.example.ssauc.user.cash.repository;
 
 import com.example.ssauc.user.cash.entity.Withdraw;
 import com.example.ssauc.user.login.entity.Users;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
@@ -11,4 +13,7 @@ import java.util.List;
 public interface WithdrawRepository extends JpaRepository<Withdraw, Long> {
     List<Withdraw> findByUser(Users user);
     List<Withdraw> findByUserAndWithdrawAtBetween(Users user, LocalDateTime start, LocalDateTime end);
+    // 페이징 처리 메서드 추가
+    Page<Withdraw> findByUser(Users user, Pageable pageable);
+    Page<Withdraw> findByUserAndWithdrawAtBetween(Users user, LocalDateTime start, LocalDateTime end, Pageable pageable);
 }

--- a/src/main/java/com/example/ssauc/user/cash/service/CashService.java
+++ b/src/main/java/com/example/ssauc/user/cash/service/CashService.java
@@ -4,10 +4,18 @@ import com.example.ssauc.user.cash.dto.CalculateDto;
 import com.example.ssauc.user.cash.dto.ChargeDto;
 import com.example.ssauc.user.cash.dto.WithdrawDto;
 import com.example.ssauc.user.login.entity.Users;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CashService {
+
     List<ChargeDto> getChargesByUser(Users user);
+    List<ChargeDto> getChargesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate);
+
     List<WithdrawDto> getWithdrawsByUser(Users user);
+    List<WithdrawDto> getWithdrawsByUser(Users user, LocalDateTime startDate, LocalDateTime endDate);
+
     List<CalculateDto> getCalculateByUser(Users user);
+    List<CalculateDto> getCalculateByUser(Users user, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/example/ssauc/user/cash/service/CashService.java
+++ b/src/main/java/com/example/ssauc/user/cash/service/CashService.java
@@ -4,6 +4,8 @@ import com.example.ssauc.user.cash.dto.CalculateDto;
 import com.example.ssauc.user.cash.dto.ChargeDto;
 import com.example.ssauc.user.cash.dto.WithdrawDto;
 import com.example.ssauc.user.login.entity.Users;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,10 +14,16 @@ public interface CashService {
 
     List<ChargeDto> getChargesByUser(Users user);
     List<ChargeDto> getChargesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate);
+    Page<ChargeDto> getChargesByUser(Users user, Pageable pageable);
+    Page<ChargeDto> getChargesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 
     List<WithdrawDto> getWithdrawsByUser(Users user);
     List<WithdrawDto> getWithdrawsByUser(Users user, LocalDateTime startDate, LocalDateTime endDate);
+    Page<WithdrawDto> getWithdrawsByUser(Users user, Pageable pageable);
+    Page<WithdrawDto> getWithdrawsByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 
     List<CalculateDto> getCalculateByUser(Users user);
     List<CalculateDto> getCalculateByUser(Users user, LocalDateTime startDate, LocalDateTime endDate);
+    Page<CalculateDto> getCalculateByUser(Users user, Pageable pageable);
+    Page<CalculateDto> getCalculateByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 }

--- a/src/main/java/com/example/ssauc/user/cash/service/CashServiceImpl.java
+++ b/src/main/java/com/example/ssauc/user/cash/service/CashServiceImpl.java
@@ -11,8 +11,11 @@ import com.example.ssauc.user.login.entity.Users;
 import com.example.ssauc.user.order.entity.Orders;
 import com.example.ssauc.user.order.repository.OrdersRepository;
 import com.example.ssauc.user.pay.entity.Payment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,6 +32,7 @@ public class CashServiceImpl implements CashService {
     @Autowired
     private OrdersRepository ordersRepository;
 
+    // ===================== 충전 내역 =====================
     @Override
     public List<ChargeDto> getChargesByUser(Users user) {
         List<Charge> charges = chargeRepository.findByUser(user);
@@ -40,6 +44,19 @@ public class CashServiceImpl implements CashService {
                 .createdAt(ch.getCreatedAt())
                 .receiptUrl(ch.getReceiptUrl())
                 .build()).collect(Collectors.toList());
+    }
+
+    @Override
+    public Page<ChargeDto> getChargesByUser(Users user, Pageable pageable) {
+        Page<Charge> chargePage = chargeRepository.findByUser(user, pageable);
+        return chargePage.map(ch -> ChargeDto.builder()
+                .chargeId(ch.getChargeId())
+                .chargeType(ch.getChargeType())
+                .amount(ch.getAmount())
+                .status(ch.getStatus())
+                .createdAt(ch.getCreatedAt())
+                .receiptUrl(ch.getReceiptUrl())
+                .build());
     }
 
     @Override
@@ -55,7 +72,20 @@ public class CashServiceImpl implements CashService {
                 .build()).collect(Collectors.toList());
     }
 
+    @Override
+    public Page<ChargeDto> getChargesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable) {
+        Page<Charge> chargePage = chargeRepository.findByUserAndCreatedAtBetween(user, startDate, endDate, pageable);
+        return chargePage.map(ch -> ChargeDto.builder()
+                .chargeId(ch.getChargeId())
+                .chargeType(ch.getChargeType())
+                .amount(ch.getAmount())
+                .status(ch.getStatus())
+                .createdAt(ch.getCreatedAt())
+                .receiptUrl(ch.getReceiptUrl())
+                .build());
+    }
 
+    // ===================== 환급 내역 =====================
     @Override
     public List<WithdrawDto> getWithdrawsByUser(Users user) {
         List<Withdraw> withdraws = withdrawRepository.findByUser(user);
@@ -71,6 +101,24 @@ public class CashServiceImpl implements CashService {
                     .requestStatus(status)
                     .build();
         }).collect(Collectors.toList());
+    }
+
+    @Override
+    public Page<WithdrawDto> getWithdrawsByUser(Users user, Pageable pageable) {
+        // ※ WithdrawRepository에 Page<Withdraw> findByUser(Users user, Pageable pageable) 메서드가 필요합니다.
+        Page<Withdraw> withdrawPage = withdrawRepository.findByUser(user, pageable);
+        return withdrawPage.map(w -> {
+            String status = (w.getWithdrawAt() != null) ? "완료" : "처리중";
+            long netAmount = (w.getAmount() != null && w.getCommission() != null) ? w.getAmount() - w.getCommission() : 0;
+            return WithdrawDto.builder()
+                    .withdrawId(w.getWithdrawId())
+                    .bank(w.getBank())
+                    .account(w.getAccount())
+                    .netAmount(netAmount)
+                    .withdrawAt(w.getWithdrawAt())
+                    .requestStatus(status)
+                    .build();
+        });
     }
 
     @Override
@@ -90,7 +138,24 @@ public class CashServiceImpl implements CashService {
         }).collect(Collectors.toList());
     }
 
+    @Override
+    public Page<WithdrawDto> getWithdrawsByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable) {
+        Page<Withdraw> withdrawPage = withdrawRepository.findByUserAndWithdrawAtBetween(user, startDate, endDate, pageable);
+        return withdrawPage.map(w -> {
+            String status = (w.getWithdrawAt() != null) ? "완료" : "처리중";
+            long netAmount = (w.getAmount() != null && w.getCommission() != null) ? w.getAmount() - w.getCommission() : 0;
+            return WithdrawDto.builder()
+                    .withdrawId(w.getWithdrawId())
+                    .bank(w.getBank())
+                    .account(w.getAccount())
+                    .netAmount(netAmount)
+                    .withdrawAt(w.getWithdrawAt())
+                    .requestStatus(status)
+                    .build();
+        });
+    }
 
+    // ===================== 결제/정산 내역 =====================
     @Override
     public List<CalculateDto> getCalculateByUser(Users user) {
         // session user가 seller 혹은 buyer인 주문 모두 조회 (동일 user를 두 파라미터로 전달)
@@ -113,6 +178,28 @@ public class CashServiceImpl implements CashService {
     }
 
     @Override
+    public Page<CalculateDto> getCalculateByUser(Users user, Pageable pageable) {
+        // ※ OrdersRepository에 Page<Orders> findBySellerOrBuyer(Users seller, Users buyer, Pageable pageable) 메서드 필요
+        Page<Orders> ordersPage = ordersRepository.findBySellerOrBuyer(user, user, pageable);
+        return ordersPage.map(order -> {
+            boolean isSeller = order.getSeller().getUserId().equals(user.getUserId());
+            Payment payment = (order.getPayments() != null && !order.getPayments().isEmpty())
+                    ? order.getPayments().get(0) : null;
+            String paymentAmount = isSeller ? ("+" + order.getTotalPrice()) : ("-" + order.getTotalPrice());
+            LocalDateTime paymentTime = isSeller ? order.getCompletedDate() :
+                    (payment != null ? payment.getPaymentDate() : null);
+            String productName = order.getProduct().getName();
+            return CalculateDto.builder()
+                    .orderId(order.getOrderId())
+                    .paymentAmount(paymentAmount)
+                    .productName(productName)
+                    .paymentTime(paymentTime)
+                    .orderStatus(order.getOrderStatus())
+                    .build();
+        });
+    }
+
+    @Override
     public List<CalculateDto> getCalculateByUser(Users user, LocalDateTime startDate, LocalDateTime endDate) {
         // 예시: OrdersRepository에 기간 조건을 추가한 메서드를 새로 정의한다고 가정
         List<Orders> orders = ordersRepository.findBySellerOrBuyerAndPaymentTimeBetween(user, user, startDate, endDate);
@@ -130,6 +217,27 @@ public class CashServiceImpl implements CashService {
                     .orderStatus(order.getOrderStatus())
                     .build();
         }).collect(Collectors.toList());
+    }
+
+    @Override
+    public Page<CalculateDto> getCalculateByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable) {
+        Page<Orders> ordersPage = ordersRepository.findBySellerOrBuyerAndPaymentTimeBetween(user, user, startDate, endDate, pageable);
+        return ordersPage.map(order -> {
+            boolean isSeller = order.getSeller().getUserId().equals(user.getUserId());
+            Payment payment = (order.getPayments() != null && !order.getPayments().isEmpty())
+                    ? order.getPayments().get(0) : null;
+            String paymentAmount = isSeller ? ("+" + order.getTotalPrice()) : ("-" + order.getTotalPrice());
+            LocalDateTime paymentTime = isSeller ? order.getCompletedDate() :
+                    (payment != null ? payment.getPaymentDate() : null);
+            String productName = order.getProduct().getName();
+            return CalculateDto.builder()
+                    .orderId(order.getOrderId())
+                    .paymentAmount(paymentAmount)
+                    .productName(productName)
+                    .paymentTime(paymentTime)
+                    .orderStatus(order.getOrderStatus())
+                    .build();
+        });
     }
 
 }

--- a/src/main/java/com/example/ssauc/user/cash/service/CashServiceImpl.java
+++ b/src/main/java/com/example/ssauc/user/cash/service/CashServiceImpl.java
@@ -101,11 +101,11 @@ public class CashServiceImpl implements CashService {
             Payment payment = (order.getPayments() != null && !order.getPayments().isEmpty()) ? order.getPayments().get(0) : null;
             String paymentAmount = isSeller ? ("+" + order.getTotalPrice()) : ("-" + order.getTotalPrice());
             LocalDateTime paymentTime = isSeller ? order.getCompletedDate() : (payment != null ? payment.getPaymentDate() : null);
-            String paymentMethod = (payment != null ? payment.getPaymentMethod() : "");
+            String productName = order.getProduct().getName();  // productName은 주문의 product 엔티티에서 가져옴
             return CalculateDto.builder()
                     .orderId(order.getOrderId())
                     .paymentAmount(paymentAmount)
-                    .paymentMethod(paymentMethod)
+                    .productName(productName)
                     .paymentTime(paymentTime)
                     .orderStatus(order.getOrderStatus())
                     .build();
@@ -121,11 +121,11 @@ public class CashServiceImpl implements CashService {
             Payment payment = (order.getPayments() != null && !order.getPayments().isEmpty()) ? order.getPayments().get(0) : null;
             String paymentAmount = isSeller ? ("+" + order.getTotalPrice()) : ("-" + order.getTotalPrice());
             LocalDateTime paymentTime = isSeller ? order.getCompletedDate() : (payment != null ? payment.getPaymentDate() : null);
-            String paymentMethod = (payment != null ? payment.getPaymentMethod() : "");
+            String productName = order.getProduct().getName();
             return CalculateDto.builder()
                     .orderId(order.getOrderId())
                     .paymentAmount(paymentAmount)
-                    .paymentMethod(paymentMethod)
+                    .productName(productName)
                     .paymentTime(paymentTime)
                     .orderStatus(order.getOrderStatus())
                     .build();

--- a/src/main/java/com/example/ssauc/user/order/repository/OrdersRepository.java
+++ b/src/main/java/com/example/ssauc/user/order/repository/OrdersRepository.java
@@ -2,6 +2,8 @@ package com.example.ssauc.user.order.repository;
 
 import com.example.ssauc.user.login.entity.Users;
 import com.example.ssauc.user.order.entity.Orders;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +14,8 @@ import java.util.List;
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
     // 세션 사용자와 seller 또는 buyer가 같은 주문을 조회 --> 결제/정산 내역에서 사용
     List<Orders> findBySellerOrBuyer(Users seller, Users buyer);
+    // 페이징 처리 메서드
+    Page<Orders> findBySellerOrBuyer(Users seller, Users buyer, Pageable pageable);
 
     @Query("SELECT o FROM Orders o LEFT JOIN o.payments p " +
             "WHERE (o.seller = :seller AND o.completedDate BETWEEN :start AND :end) " +
@@ -20,6 +24,16 @@ public interface OrdersRepository extends JpaRepository<Orders, Long> {
                                                           @Param("buyer") Users buyer,
                                                           @Param("start") LocalDateTime start,
                                                           @Param("end") LocalDateTime end);
+
+    // 날짜 필터 포함한 페이징 예시 (JPQL 또는 Query 메서드 사용)
+    @Query("SELECT o FROM Orders o LEFT JOIN o.payments p " +
+            "WHERE (o.seller = :seller AND o.completedDate BETWEEN :start AND :end) " +
+            "OR (o.buyer = :buyer AND p.paymentDate BETWEEN :start AND :end)")
+    Page<Orders> findBySellerOrBuyerAndPaymentTimeBetween(@Param("seller") Users seller,
+                                                          @Param("buyer") Users buyer,
+                                                          @Param("start") LocalDateTime start,
+                                                          @Param("end") LocalDateTime end,
+                                                          Pageable pageable);
 
 
 }

--- a/src/main/java/com/example/ssauc/user/order/repository/OrdersRepository.java
+++ b/src/main/java/com/example/ssauc/user/order/repository/OrdersRepository.java
@@ -3,10 +3,23 @@ package com.example.ssauc.user.order.repository;
 import com.example.ssauc.user.login.entity.Users;
 import com.example.ssauc.user.order.entity.Orders;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
     // 세션 사용자와 seller 또는 buyer가 같은 주문을 조회 --> 결제/정산 내역에서 사용
     List<Orders> findBySellerOrBuyer(Users seller, Users buyer);
+
+    @Query("SELECT o FROM Orders o LEFT JOIN o.payments p " +
+            "WHERE (o.seller = :seller AND o.completedDate BETWEEN :start AND :end) " +
+            "OR (o.buyer = :buyer AND p.paymentDate BETWEEN :start AND :end)")
+    List<Orders> findBySellerOrBuyerAndPaymentTimeBetween(@Param("seller") Users seller,
+                                                          @Param("buyer") Users buyer,
+                                                          @Param("start") LocalDateTime start,
+                                                          @Param("end") LocalDateTime end);
+
+
 }

--- a/src/main/resources/templates/cash/cash.html
+++ b/src/main/resources/templates/cash/cash.html
@@ -35,9 +35,15 @@
     <div class="history-header">
       <h2> 쏙머니 내역</h2>
       <div class="date-filter">
-        <label>조회 기간</label>
-        <input type="date"> ~ <input type="date">
-        <button class="search-btn">조회</button>
+        <form action="/cash/cash" method="get">
+          <!-- 현재 선택된 필터 유지 (예: charge, withdraw, calculate) -->
+          <input type="hidden" name="filter" th:value="${filter}">
+          <label>조회 기간</label>
+          <input type="date" name="startDate" value="" placeholder="시작일">
+          ~
+          <input type="date" name="endDate" value="" placeholder="종료일">
+          <button type="submit" class="search-btn">조회</button>
+        </form>
       </div>
     </div>
     <!--        <button class="filter-btn active" onclick="setActiveFilter(this)">결제 / 정산</button>-->

--- a/src/main/resources/templates/cash/cash.html
+++ b/src/main/resources/templates/cash/cash.html
@@ -145,14 +145,22 @@
 
     <!-- 페이지네이션 -->
     <div class="pagination">
-      <button><</button>
-      <button class="active">1</button>
-      <button>2</button>
-      <button>3</button>
-      <button>4</button>
-      <button>5</button>
-      <button>></button>
+      <!-- 이전 페이지 버튼 (현재 페이지가 1보다 클 때만 표시) -->
+      <a th:if="${currentPage > 1}"
+         th:href="@{/cash/cash(filter=${filter}, page=${currentPage - 1}, startDate=${startDate}, endDate=${endDate})}"><button><</button></a>
+
+      <!-- 페이지 번호 버튼 -->
+      <span th:each="i : ${#numbers.sequence(1, totalPages)}">
+    <a th:href="@{/cash/cash(filter=${filter}, page=${i}, startDate=${startDate}, endDate=${endDate})}">
+      <button th:text="${i}" th:classappend="${i == currentPage} ? ' active'"></button>
+    </a>
+  </span>
+
+      <!-- 다음 페이지 버튼 (현재 페이지가 총 페이지 수보다 작을 때만 표시) -->
+      <a th:if="${currentPage < totalPages}"
+         th:href="@{/cash/cash(filter=${filter}, page=${currentPage + 1}, startDate=${startDate}, endDate=${endDate})}"><button>></button></a>
     </div>
+
   </main>
 </div>
 

--- a/src/main/resources/templates/cash/cash.html
+++ b/src/main/resources/templates/cash/cash.html
@@ -122,8 +122,8 @@
         <thead>
         <tr>
           <th>결제/정산 ID</th>
+          <th>거래 상품명</th>
           <th>결제/정산 금액</th>
-          <th>결제/정산 방식</th>
           <th>결제/정산 시간</th>
           <th>결제/정산 상태</th>
         </tr>
@@ -131,11 +131,11 @@
         <tbody>
         <tr th:each="calculate : ${calculateList}">
           <td th:text="${calculate.orderId}">1</td>
+          <td th:text="${calculate.productName}">상품명</td>
           <td th:text="${(calculate.paymentAmount.substring(0,1)) +
                T(java.lang.String).format('%,d', T(java.lang.Long).parseLong(calculate.paymentAmount.substring(1)))}">
             +1,600,000
           </td>
-          <td th:text="${calculate.paymentMethod}">신용카드</td>
           <td th:text="${#temporals.format(calculate.paymentTime, 'yyyy-MM-dd HH:mm')}">2025-02-26 10:30</td>
           <td th:text="${calculate.orderStatus}">완료</td>
         </tr>
@@ -155,21 +155,6 @@
     </div>
   </main>
 </div>
-
-<!-- 필터 버튼 클릭 이벤트 -->
-<!--<script layout:fragment="script">-->
-<!--  function setActiveFilter(selectedButton) {-->
-<!--    // 모든 버튼에서 active 클래스를 제거하여 기본 스타일(흰색 배경, 검은색 테두리 및 글씨)을 적용-->
-<!--    const buttons = document.querySelectorAll(".filter-btn");-->
-<!--    buttons.forEach(button => {-->
-<!--      button.classList.remove("active");-->
-<!--    });-->
-<!--    // 클릭한 버튼에만 active 클래스를 추가하여 검은색 배경, 흰색 글씨를 적용-->
-<!--    selectedButton.classList.add("active");-->
-
-<!--    // 이후 필터 조건에 따른 데이터를 가져오는 로직을 추가할 수 있습니다.-->
-<!--  }-->
-<!--</script>-->
 
 </body>
 </html>


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 작업 내용 입력 -->
쏙머니 충전, 환급, 결제/정산 내역에 기간별 조회 기능 추가
결제/정산 내역에 정산 방식 삭제
결제/정산 내역에 거래 대상 상품 정보 추가
모든 내역(각 필터별, 기간별 조회)에 10개의 내역 단위로 페이징 기능 추가 

## 📎 Issue 번호
<!-- closed #번호 -->
#91 