### PR TITLE
쏙머니 내역 추가 기능 구현

### DIFF
--- a/src/main/java/com/example/ssauc/user/cash/controller/CashController.java
+++ b/src/main/java/com/example/ssauc/user/cash/controller/CashController.java
@@ -28,7 +28,7 @@ public class CashController {
     private CashService cashService;
 
     @GetMapping("/cash")
-    public String cashPage(@RequestParam(value = "filter", required = false, defaultValue = "calculate") String filter,
+    public String cashPage(@RequestParam(value = "filter", required = false, defaultValue = "payment") String filter,
                            @RequestParam(value = "startDate", required = false) String startDateStr,
                            @RequestParam(value = "endDate", required = false) String endDateStr,
                            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
@@ -93,17 +93,6 @@ public class CashController {
             Page<CalculateDto> calculatePage = (startDate != null && endDate != null) ?
                     cashService.getSettlementCalculatesByUser(user, startDate, endDate, pageable) :
                     cashService.getSettlementCalculatesByUser(user, pageable);
-            model.addAttribute("calculateList", calculatePage.getContent());
-            model.addAttribute("totalPages", calculatePage.getTotalPages());
-            model.addAttribute("currentPage", page);
-        } else if ("calculate".equals(filter)) {
-            // 결제/정산 내역
-            Page<CalculateDto> calculatePage;
-            if (startDate != null && endDate != null) {
-                calculatePage = cashService.getCalculateByUser(user, startDate, endDate, pageable);
-            } else {
-                calculatePage = cashService.getCalculateByUser(user, pageable);
-            }
             model.addAttribute("calculateList", calculatePage.getContent());
             model.addAttribute("totalPages", calculatePage.getTotalPages());
             model.addAttribute("currentPage", page);

--- a/src/main/java/com/example/ssauc/user/cash/controller/CashController.java
+++ b/src/main/java/com/example/ssauc/user/cash/controller/CashController.java
@@ -43,7 +43,7 @@ public class CashController {
 
         LocalDateTime startDate = null;
         LocalDateTime endDate = null;
-        if(startDateStr != null && !startDateStr.isEmpty() && endDateStr != null && !endDateStr.isEmpty()){
+        if (startDateStr != null && !startDateStr.isEmpty() && endDateStr != null && !endDateStr.isEmpty()) {
             // 변환 예시: 시작일은 00:00, 종료일은 23:59:59로 설정
             startDate = LocalDate.parse(startDateStr).atStartOfDay();
             endDate = LocalDate.parse(endDateStr).atTime(23, 59, 59);
@@ -59,8 +59,9 @@ public class CashController {
 
         // 날짜 필터가 있는 경우와 없는 경우를 분기해서 처리
         if ("charge".equals(filter)) {
+            // 충전 내역
             Page<ChargeDto> chargePage;
-            if(startDate != null && endDate != null){
+            if (startDate != null && endDate != null) {
                 chargePage = cashService.getChargesByUser(user, startDate, endDate, pageable);
             } else {
                 chargePage = cashService.getChargesByUser(user, pageable);
@@ -69,8 +70,9 @@ public class CashController {
             model.addAttribute("totalPages", chargePage.getTotalPages());
             model.addAttribute("currentPage", page);
         } else if ("withdraw".equals(filter)) {
+            // 환급 내역
             Page<WithdrawDto> withdrawPage;
-            if(startDate != null && endDate != null){
+            if (startDate != null && endDate != null) {
                 withdrawPage = cashService.getWithdrawsByUser(user, startDate, endDate, pageable);
             } else {
                 withdrawPage = cashService.getWithdrawsByUser(user, pageable);
@@ -78,9 +80,26 @@ public class CashController {
             model.addAttribute("withdrawList", withdrawPage.getContent());
             model.addAttribute("totalPages", withdrawPage.getTotalPages());
             model.addAttribute("currentPage", page);
+        } else if ("payment".equals(filter)) {
+            // 결제 내역 (구매한 주문만)
+            Page<CalculateDto> calculatePage = (startDate != null && endDate != null) ?
+                    cashService.getPaymentCalculatesByUser(user, startDate, endDate, pageable) :
+                    cashService.getPaymentCalculatesByUser(user, pageable);
+            model.addAttribute("calculateList", calculatePage.getContent());
+            model.addAttribute("totalPages", calculatePage.getTotalPages());
+            model.addAttribute("currentPage", page);
+        } else if ("settlement".equals(filter)) {
+            // 정산 내역 (판매한 주문만)
+            Page<CalculateDto> calculatePage = (startDate != null && endDate != null) ?
+                    cashService.getSettlementCalculatesByUser(user, startDate, endDate, pageable) :
+                    cashService.getSettlementCalculatesByUser(user, pageable);
+            model.addAttribute("calculateList", calculatePage.getContent());
+            model.addAttribute("totalPages", calculatePage.getTotalPages());
+            model.addAttribute("currentPage", page);
         } else if ("calculate".equals(filter)) {
+            // 결제/정산 내역
             Page<CalculateDto> calculatePage;
-            if(startDate != null && endDate != null){
+            if (startDate != null && endDate != null) {
                 calculatePage = cashService.getCalculateByUser(user, startDate, endDate, pageable);
             } else {
                 calculatePage = cashService.getCalculateByUser(user, pageable);
@@ -116,7 +135,7 @@ public class CashController {
     @ResponseBody
     public ResponseEntity<?> completePayment(@RequestBody ChargeRequestDto request, HttpSession session) {
         Users user = (Users) session.getAttribute("user");
-        if(user == null) {
+        if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
         }
         try {
@@ -148,13 +167,13 @@ public class CashController {
     @ResponseBody
     public ResponseEntity<?> requestWithdraw(@RequestBody WithdrawRequestDto request, HttpSession session) {
         Users user = (Users) session.getAttribute("user");
-        if(user == null) {
+        if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
         }
         try {
             Withdraw withdraw = cashService.requestWithdraw(user, request.getAmount(), request.getBank(), request.getAccount());
             return ResponseEntity.ok("환급 요청이 접수되었습니다.");
-        } catch(Exception e) {
+        } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("환급 요청 처리 중 오류 발생");
         }
     }

--- a/src/main/java/com/example/ssauc/user/cash/dto/CalculateDto.java
+++ b/src/main/java/com/example/ssauc/user/cash/dto/CalculateDto.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Builder
 public class CalculateDto {
     private Long orderId;
-    private String paymentAmount;   // "+" 또는 "-" 접두어와 total_price
+    private Long paymentAmount;
     private String productName;     // orders에서 가져온 상품 이름
     private LocalDateTime paymentTime;  // 판매자: orders.completedDate, 구매자: payment.paymentDate
     private String orderStatus;     // orders.order_status

--- a/src/main/java/com/example/ssauc/user/cash/repository/ChargeRepository.java
+++ b/src/main/java/com/example/ssauc/user/cash/repository/ChargeRepository.java
@@ -5,6 +5,8 @@ import com.example.ssauc.user.login.entity.Users;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 
@@ -12,4 +14,16 @@ public interface ChargeRepository extends JpaRepository<Charge, Long> {
     // 페이징 처리 메서드 추가
     Page<Charge> findByUser(Users user, Pageable pageable);
     Page<Charge> findByUserAndCreatedAtBetween(Users user, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+    // 기간 별 총 금액 계산
+    // 기간 조회 x
+    @Query("SELECT COALESCE(SUM(c.amount), 0) FROM Charge c WHERE c.user = :user AND c.status = '충전완료'")
+    long sumAmountByUser(@Param("user") Users user);
+    // 기간 조회 o
+    @Query("SELECT COALESCE(SUM(c.amount), 0) FROM Charge c WHERE c.user = :user AND c.createdAt BETWEEN :start AND :end AND c.status = '충전완료'")
+    long sumAmountByUserAndCreatedAtBetween(@Param("user") Users user,
+                                            @Param("start") LocalDateTime start,
+                                            @Param("end") LocalDateTime end);
+
+
 }

--- a/src/main/java/com/example/ssauc/user/cash/repository/WithdrawRepository.java
+++ b/src/main/java/com/example/ssauc/user/cash/repository/WithdrawRepository.java
@@ -5,6 +5,8 @@ import com.example.ssauc.user.login.entity.Users;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 
@@ -15,4 +17,14 @@ public interface WithdrawRepository extends JpaRepository<Withdraw, Long> {
     Page<Withdraw> findByUserAndWithdrawAtBetween(Users user, LocalDateTime start, LocalDateTime end, Pageable pageable);
     // 현재 월 환급 신청 건수 확인용 메서드 추가
     int countByUserAndRequestedAtBetween(Users user, LocalDateTime start, LocalDateTime end);
+
+    // 기간 별 총 금액 계산
+    // 기간 조회 x
+    @Query("SELECT COALESCE(SUM(w.amount - w.commission), 0) FROM Withdraw w WHERE w.user = :user AND w.withdrawAt IS NOT NULL")
+    long sumNetAmountByUser(@Param("user") Users user);
+    // 기간 조회 o
+    @Query("SELECT COALESCE(SUM(w.amount - w.commission), 0) FROM Withdraw w WHERE w.user = :user AND w.withdrawAt BETWEEN :start AND :end")
+    long sumNetAmountByUserAndWithdrawAtBetween(@Param("user") Users user,
+                                                @Param("start") LocalDateTime start,
+                                                @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/example/ssauc/user/cash/service/CashService.java
+++ b/src/main/java/com/example/ssauc/user/cash/service/CashService.java
@@ -18,14 +18,21 @@ public interface CashService {
     // 이번 달 환급 신청 횟수를 반환하는 메서드 추가
     int getCurrentWithdrawCount(Users user);
 
+    Page<CalculateDto> getCalculateByUser(Users user, Pageable pageable);
+    Page<CalculateDto> getCalculateByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+
+    Page<CalculateDto> getPaymentCalculatesByUser(Users user, Pageable pageable);
+    Page<CalculateDto> getPaymentCalculatesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+
+    Page<CalculateDto> getSettlementCalculatesByUser(Users user, Pageable pageable);
+    Page<CalculateDto> getSettlementCalculatesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+
     Page<ChargeDto> getChargesByUser(Users user, Pageable pageable);
     Page<ChargeDto> getChargesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 
     Page<WithdrawDto> getWithdrawsByUser(Users user, Pageable pageable);
     Page<WithdrawDto> getWithdrawsByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 
-    Page<CalculateDto> getCalculateByUser(Users user, Pageable pageable);
-    Page<CalculateDto> getCalculateByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 
     // PortOne API를 통해 결제 정보를 검증, 결제 완료 처리.
     Charge verifyAndCompletePayment(String paymentId, Long amount, Users user) throws PortoneVerificationException;

--- a/src/main/java/com/example/ssauc/user/cash/service/CashService.java
+++ b/src/main/java/com/example/ssauc/user/cash/service/CashService.java
@@ -18,18 +18,16 @@ public interface CashService {
     // 이번 달 환급 신청 횟수를 반환하는 메서드 추가
     int getCurrentWithdrawCount(Users user);
 
-    Page<CalculateDto> getCalculateByUser(Users user, Pageable pageable);
-    Page<CalculateDto> getCalculateByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
-
+    // 결제 내역
     Page<CalculateDto> getPaymentCalculatesByUser(Users user, Pageable pageable);
     Page<CalculateDto> getPaymentCalculatesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
-
+    // 정산 내역
     Page<CalculateDto> getSettlementCalculatesByUser(Users user, Pageable pageable);
     Page<CalculateDto> getSettlementCalculatesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
-
+    // 충전 내역
     Page<ChargeDto> getChargesByUser(Users user, Pageable pageable);
     Page<ChargeDto> getChargesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
-
+    // 환급 내역
     Page<WithdrawDto> getWithdrawsByUser(Users user, Pageable pageable);
     Page<WithdrawDto> getWithdrawsByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 

--- a/src/main/java/com/example/ssauc/user/cash/service/CashService.java
+++ b/src/main/java/com/example/ssauc/user/cash/service/CashService.java
@@ -13,36 +13,43 @@ import java.time.LocalDateTime;
 
 public interface CashService {
 
-    // 환급 신청 처리 (수수료 계산 포함)
-    Withdraw requestWithdraw(Users user, Long amount, String bank, String account);
-    // 이번 달 환급 신청 횟수를 반환하는 메서드 추가
-    int getCurrentWithdrawCount(Users user);
+    Users getCurrentUser(Long userId);
 
-    // 결제 내역
+    // ===================== 결제 내역 =====================
     Page<CalculateDto> getPaymentCalculatesByUser(Users user, Pageable pageable);
     Page<CalculateDto> getPaymentCalculatesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
-    // 정산 내역
+    // ===================== 정산 내역 =====================
     Page<CalculateDto> getSettlementCalculatesByUser(Users user, Pageable pageable);
     Page<CalculateDto> getSettlementCalculatesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
-    // 충전 내역
+    // ===================== 충전 내역 =====================
     Page<ChargeDto> getChargesByUser(Users user, Pageable pageable);
     Page<ChargeDto> getChargesByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
-    // 환급 내역
+    // ===================== 환급 내역 =====================
     Page<WithdrawDto> getWithdrawsByUser(Users user, Pageable pageable);
     Page<WithdrawDto> getWithdrawsByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 
     // 각 내역별 총합 계산 메서드 추가
-    long getTotalChargeAmount(Users user);
-    long getTotalChargeAmount(Users user, LocalDateTime startDate, LocalDateTime endDate);
-    long getTotalWithdrawAmount(Users user);
-    long getTotalWithdrawAmount(Users user, LocalDateTime startDate, LocalDateTime endDate);
+    // ===================== 결제 금액 총합 =====================
     long getTotalPaymentAmount(Users user);
     long getTotalPaymentAmount(Users user, LocalDateTime startDate, LocalDateTime endDate);
+    // ===================== 정산 금액 총합 =====================
     long getTotalSettlementAmount(Users user);
     long getTotalSettlementAmount(Users user, LocalDateTime startDate, LocalDateTime endDate);
+    // ===================== 충전 금액 총합 =====================
+    long getTotalChargeAmount(Users user);
+    long getTotalChargeAmount(Users user, LocalDateTime startDate, LocalDateTime endDate);
+    // ===================== 환급 금액 총합 =====================
+    long getTotalWithdrawAmount(Users user);
+    long getTotalWithdrawAmount(Users user, LocalDateTime startDate, LocalDateTime endDate);
 
     // PortOne 결제 처리
     Charge verifyAndCompletePayment(String paymentId, Long amount, Users user) throws PortoneVerificationException;
+
+    // 환급 신청 처리 (수수료 계산 포함)
+    Withdraw requestWithdraw(Users user, Long amount, String bank, String account);
+
+    // 이번 달 환급 신청 횟수를 반환하는 메서드 추가
+    int getCurrentWithdrawCount(Users user);
 
     /**
      * PortOne에서 전달받은 웹훅 요청을 처리합니다.

--- a/src/main/java/com/example/ssauc/user/cash/service/CashService.java
+++ b/src/main/java/com/example/ssauc/user/cash/service/CashService.java
@@ -31,8 +31,17 @@ public interface CashService {
     Page<WithdrawDto> getWithdrawsByUser(Users user, Pageable pageable);
     Page<WithdrawDto> getWithdrawsByUser(Users user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 
+    // 각 내역별 총합 계산 메서드 추가
+    long getTotalChargeAmount(Users user);
+    long getTotalChargeAmount(Users user, LocalDateTime startDate, LocalDateTime endDate);
+    long getTotalWithdrawAmount(Users user);
+    long getTotalWithdrawAmount(Users user, LocalDateTime startDate, LocalDateTime endDate);
+    long getTotalPaymentAmount(Users user);
+    long getTotalPaymentAmount(Users user, LocalDateTime startDate, LocalDateTime endDate);
+    long getTotalSettlementAmount(Users user);
+    long getTotalSettlementAmount(Users user, LocalDateTime startDate, LocalDateTime endDate);
 
-    // PortOne API를 통해 결제 정보를 검증, 결제 완료 처리.
+    // PortOne 결제 처리
     Charge verifyAndCompletePayment(String paymentId, Long amount, Users user) throws PortoneVerificationException;
 
     /**

--- a/src/main/java/com/example/ssauc/user/cash/service/CashServiceImpl.java
+++ b/src/main/java/com/example/ssauc/user/cash/service/CashServiceImpl.java
@@ -389,7 +389,7 @@ public class CashServiceImpl implements CashService {
         chargeRepository.save(charge);
 
         // 7. 결제 성공 시 사용자 잔액 업데이트 (결과를 DB에 반영)
-        if ("PAID".equalsIgnoreCase(status)) {
+        if ("충전완료".equalsIgnoreCase(status)) {
             // 예시: 사용자 객체의 캐시 값을 업데이트하고, 세션에 다시 저장
             user.setCash(user.getCash() + parsedAmount);
             usersRepository.save(user);

--- a/src/main/java/com/example/ssauc/user/history/controller/HistoryController.java
+++ b/src/main/java/com/example/ssauc/user/history/controller/HistoryController.java
@@ -1,8 +1,11 @@
 package com.example.ssauc.user.history.controller;
 
 import com.example.ssauc.user.history.dto.BanHistoryDto;
-import com.example.ssauc.user.history.repository.BanHistoryService;
+import com.example.ssauc.user.history.service.HistoryService;
+import com.example.ssauc.user.login.entity.Users;
+
 import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -12,35 +15,26 @@ import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("history")
+@RequiredArgsConstructor
 public class HistoryController {
 
-    private final BanHistoryService banHistoryService;
+    private final HistoryService banHistoryService;
 
-    public HistoryController(BanHistoryService banHistoryService) {
-        this.banHistoryService = banHistoryService;
-    }
-
-//    @GetMapping("history")
-//    public String history() {
-//        return "/history/history";
-//    }
-
-    //    @GetMapping("/ban")
-//    public String banPage() {
-//        return "/history/ban";
-//    }
+    private final HistoryService historyService;
 
     // 차단 내역 페이지: 로그인한 사용자의 차단 내역 조회
     @GetMapping("/ban")
-    public String banPage(Model model, HttpSession session,
-                          @RequestParam(defaultValue = "1") int page) {
-        Long userId = (Long) session.getAttribute("userId");
-        if (userId == null) {
+    public String banPage(@RequestParam(defaultValue = "1") int page,
+                          HttpSession session, Model model) {
+        Users user = (Users) session.getAttribute("user");
+        if (user == null) {
             return "redirect:/login";
         }
+        Users latestUser = historyService.getCurrentUser(user.getUserId());
+        model.addAttribute("user", latestUser);
         // 페이지 번호는 0부터 시작하므로 (page - 1)로 변환
         Pageable pageable = PageRequest.of(page - 1, 10);
-        Page<BanHistoryDto> banPage = banHistoryService.getBanListForUser(userId, pageable);
+        Page<BanHistoryDto> banPage = banHistoryService.getBanListForUser(latestUser.getUserId(), pageable);
         model.addAttribute("banList", banPage.getContent());
         model.addAttribute("currentPage", page);
         model.addAttribute("totalPages", banPage.getTotalPages());
@@ -49,37 +43,56 @@ public class HistoryController {
 
     // 차단 해제 요청 처리
     @PostMapping("/ban/unban")
-    public String unbanUser(@RequestParam("banId") Long banId, HttpSession session) {
-        Long userId = (Long) session.getAttribute("userId");
-        if (userId == null) {
+    public String unbanUser(@RequestParam("banId") Long banId,
+                            HttpSession session, Model model) {
+        Users user = (Users) session.getAttribute("user");
+        if (user == null) {
             return "redirect:/login";
         }
-        banHistoryService.unbanUser(banId, userId);
+        Users latestUser = historyService.getCurrentUser(user.getUserId());
+        model.addAttribute("user", latestUser);
+
+        banHistoryService.unbanUser(banId, latestUser.getUserId());
         return "redirect:/history/ban";
     }
 
     @GetMapping("/reported")  // 리뷰 내역 페이지로 이동
-    public String reportedPage() {
+    public String reportedPage(HttpSession session, Model model) {
+        Users user = (Users) session.getAttribute("user");
+        Users latestUser = historyService.getCurrentUser(user.getUserId());
+        model.addAttribute("user", latestUser);
         return "/history/reported";
     }
 
     @GetMapping("/sell")  // 판매 현황 리스트 페이지로 이동
-    public String sellPage() {
+    public String sellPage(HttpSession session, Model model) {
+        Users user = (Users) session.getAttribute("user");
+        Users latestUser = historyService.getCurrentUser(user.getUserId());
+        model.addAttribute("user", latestUser);
         return "/history/sell";
     }
 
     @GetMapping("/sold")  // 판매 현황 상세 페이지로 이동
-    public String soldPage() {
+    public String soldPage(HttpSession session, Model model) {
+        Users user = (Users) session.getAttribute("user");
+        Users latestUser = historyService.getCurrentUser(user.getUserId());
+        model.addAttribute("user", latestUser);
         return "/history/sold";
     }
 
     @GetMapping("/buy")  // 구매 현황 리스트 페이지로 이동
-    public String buyPage() {
+    public String buyPage(HttpSession session, Model model) {
+        Users user = (Users) session.getAttribute("user");
+        Users latestUser = historyService.getCurrentUser(user.getUserId());
+        model.addAttribute("user", latestUser);
         return "/history/buy";
     }
 
     @GetMapping("/bought")  // 구매 현황 리스트 페이지로 이동
-    public String boughtPage() {
+    public String boughtPage(HttpSession session, Model model) {
+        Users user = (Users) session.getAttribute("user");
+        Users latestUser = historyService.getCurrentUser(user.getUserId());
+        model.addAttribute("user", latestUser);
         return "/history/bought";
     }
 }

--- a/src/main/java/com/example/ssauc/user/history/service/HistoryService.java
+++ b/src/main/java/com/example/ssauc/user/history/service/HistoryService.java
@@ -1,20 +1,28 @@
-package com.example.ssauc.user.history.repository;
+package com.example.ssauc.user.history.service;
 
 import com.example.ssauc.user.chat.entity.Ban;
 import com.example.ssauc.user.history.dto.BanHistoryDto;
 import com.example.ssauc.user.chat.repository.BanRepository;
+import com.example.ssauc.user.login.entity.Users;
+import com.example.ssauc.user.login.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class BanHistoryService {
+@RequiredArgsConstructor
+public class HistoryService {
+
+    private final UsersRepository usersRepository;
 
     private final BanRepository banRepository;
 
-    public BanHistoryService(BanRepository banRepository) {
-        this.banRepository = banRepository;
+    // 세션에서 전달된 userId를 이용하여 DB에서 최신 사용자 정보를 조회합니다.
+    public Users getCurrentUser(Long userId) {
+        return usersRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자 정보가 없습니다."));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/ssauc/user/mypage/controller/MypageController.java
+++ b/src/main/java/com/example/ssauc/user/mypage/controller/MypageController.java
@@ -1,35 +1,51 @@
 package com.example.ssauc.user.mypage.controller;
 
+import com.example.ssauc.user.login.entity.Users;
 import com.example.ssauc.user.mypage.service.MypageService;
-import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
+@RequiredArgsConstructor
 @RequestMapping("/mypage")  // "/mypage" 경로로 들어오는 요청을 처리
 public class MypageController {
 
-    @Autowired
-    private MypageService mypageService;
+    private final MypageService mypageService;
 
     @GetMapping  // GET 요청을 받아서 mypage.html을 반환
-    public String mypage() {
-        return "mypage/mypage"; // templates/mypage/mypage.html 파일을 렌더링
+    public String mypage(HttpSession session, Model model) {
+        // DB에서 최신 사용자 정보를 조회
+        Users user = (Users) session.getAttribute("user");
+        Users latestUser = mypageService.getCurrentUser(user.getUserId());
+        model.addAttribute("user", latestUser);
+        return "/mypage/mypage"; // templates/mypage/mypage.html
     }
 
     @GetMapping("/evaluate")  // 리뷰 작성 페이지로 이동
-    public String evaluatePage() {
+    public String evaluatePage(HttpSession session, Model model) {
+        Users user = (Users) session.getAttribute("user");
+        Users latestUser = mypageService.getCurrentUser(user.getUserId());
+        model.addAttribute("user", latestUser);
         return "/mypage/evaluate";
     }
 
     @GetMapping("/evaluation")  // 리뷰 내역 페이지로 이동
-    public String evaluationPage() {
+    public String evaluationPage(HttpSession session, Model model) {
+        Users user = (Users) session.getAttribute("user");
+        Users latestUser = mypageService.getCurrentUser(user.getUserId());
+        model.addAttribute("user", latestUser);
         return "/mypage/evaluation";
     }
 
     @GetMapping("/evaluated")  // 리뷰 상세 페이지로 이동
-    public String evaluatedPage() {
+    public String evaluatedPage(HttpSession session, Model model) {
+        Users user = (Users) session.getAttribute("user");
+        Users latestUser = mypageService.getCurrentUser(user.getUserId());
+        model.addAttribute("user", latestUser);
         return "/mypage/evaluated";
     }
 

--- a/src/main/java/com/example/ssauc/user/mypage/service/MypageService.java
+++ b/src/main/java/com/example/ssauc/user/mypage/service/MypageService.java
@@ -3,5 +3,5 @@ package com.example.ssauc.user.mypage.service;
 import com.example.ssauc.user.login.entity.Users;
 
 public interface MypageService {
-    Users getCurrentUser();
+    Users getCurrentUser(Long userId);
 }

--- a/src/main/java/com/example/ssauc/user/mypage/service/MypageServiceImpl.java
+++ b/src/main/java/com/example/ssauc/user/mypage/service/MypageServiceImpl.java
@@ -2,19 +2,19 @@ package com.example.ssauc.user.mypage.service;
 
 import com.example.ssauc.user.login.entity.Users;
 import com.example.ssauc.user.login.repository.UsersRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class MypageServiceImpl implements MypageService {
 
-    @Autowired
-    private UsersRepository usersRepository;
+    private final UsersRepository usersRepository;
 
+    // 세션에서 전달된 userId를 이용하여 DB에서 최신 사용자 정보를 조회합니다.
     @Override
-    public Users getCurrentUser() {
-        // 예시: 현재 로그인한 유저 정보를 Security Context나 세션에서 가져오는 로직을 구현해야 함.
-        // 여기서는 단순하게 userId 1번 유저를 조회하는 예시입니다.
-        return usersRepository.findById(1L).orElse(null);
+    public Users getCurrentUser(Long userId) {
+        return usersRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자 정보가 없습니다."));
     }
 }

--- a/src/main/java/com/example/ssauc/user/order/repository/OrdersRepository.java
+++ b/src/main/java/com/example/ssauc/user/order/repository/OrdersRepository.java
@@ -9,23 +9,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
     // 세션 사용자와 seller 또는 buyer가 같은 주문을 조회 --> 결제/정산 내역에서 사용
-    List<Orders> findBySellerOrBuyer(Users seller, Users buyer);
-    // 페이징 처리 메서드
     Page<Orders> findBySellerOrBuyer(Users seller, Users buyer, Pageable pageable);
-
-    @Query("SELECT o FROM Orders o LEFT JOIN o.payments p " +
-            "WHERE (o.seller = :seller AND o.completedDate BETWEEN :start AND :end) " +
-            "OR (o.buyer = :buyer AND p.paymentDate BETWEEN :start AND :end)")
-    List<Orders> findBySellerOrBuyerAndPaymentTimeBetween(@Param("seller") Users seller,
-                                                          @Param("buyer") Users buyer,
-                                                          @Param("start") LocalDateTime start,
-                                                          @Param("end") LocalDateTime end);
-
-    // 날짜 필터 포함한 페이징 예시 (JPQL 또는 Query 메서드 사용)
+    // 날짜 필터 포함한 페이징
     @Query("SELECT o FROM Orders o LEFT JOIN o.payments p " +
             "WHERE (o.seller = :seller AND o.completedDate BETWEEN :start AND :end) " +
             "OR (o.buyer = :buyer AND p.paymentDate BETWEEN :start AND :end)")
@@ -34,6 +22,22 @@ public interface OrdersRepository extends JpaRepository<Orders, Long> {
                                                           @Param("start") LocalDateTime start,
                                                           @Param("end") LocalDateTime end,
                                                           Pageable pageable);
+
+    // 결제 내역 (구매자 기준 주문) 조회
+    Page<Orders> findByBuyer(Users buyer, Pageable pageable);
+    // 날짜 필터 포함한 페이징
+    @Query("SELECT o FROM Orders o LEFT JOIN o.payments p " +
+            "WHERE o.buyer = :buyer AND p.paymentDate BETWEEN :start AND :end")
+    Page<Orders> findByBuyerAndPaymentTimeBetween(@Param("buyer") Users buyer,
+                                                  @Param("start") LocalDateTime start,
+                                                  @Param("end") LocalDateTime end,
+                                                  Pageable pageable);
+
+    // 정산 내역 (판매자 기준 주문) 조회
+    Page<Orders> findBySeller(Users seller, Pageable pageable);
+    // 날짜 필터 포함한 페이징
+    Page<Orders> findBySellerAndCompletedDateBetween(Users seller, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+
 
 
 }

--- a/src/main/java/com/example/ssauc/user/order/repository/OrdersRepository.java
+++ b/src/main/java/com/example/ssauc/user/order/repository/OrdersRepository.java
@@ -11,17 +11,6 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
-    // 세션 사용자와 seller 또는 buyer가 같은 주문을 조회 --> 결제/정산 내역에서 사용
-    Page<Orders> findBySellerOrBuyer(Users seller, Users buyer, Pageable pageable);
-    // 날짜 필터 포함한 페이징
-    @Query("SELECT o FROM Orders o LEFT JOIN o.payments p " +
-            "WHERE (o.seller = :seller AND o.completedDate BETWEEN :start AND :end) " +
-            "OR (o.buyer = :buyer AND p.paymentDate BETWEEN :start AND :end)")
-    Page<Orders> findBySellerOrBuyerAndPaymentTimeBetween(@Param("seller") Users seller,
-                                                          @Param("buyer") Users buyer,
-                                                          @Param("start") LocalDateTime start,
-                                                          @Param("end") LocalDateTime end,
-                                                          Pageable pageable);
 
     // 결제 내역 (구매자 기준 주문) 조회
     Page<Orders> findByBuyer(Users buyer, Pageable pageable);

--- a/src/main/java/com/example/ssauc/user/product/service/ProductService.java
+++ b/src/main/java/com/example/ssauc/user/product/service/ProductService.java
@@ -1,6 +1,7 @@
 package com.example.ssauc.user.product.service;
 
 import com.example.ssauc.user.login.entity.Users;
+import com.example.ssauc.user.login.repository.UsersRepository;
 import com.example.ssauc.user.product.dto.ProductInsertDto;
 import com.example.ssauc.user.product.entity.Category;
 import com.example.ssauc.user.product.entity.Product;
@@ -17,8 +18,14 @@ import java.time.LocalTime;
 @RequiredArgsConstructor
 public class ProductService {
 
+    private final UsersRepository usersRepository;
     private final ProductRepository productRepository;
     private final CategoryRepository categoryRepository;
+
+    public Users getCurrentUser(Long userId) {
+        return usersRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자 정보가 없습니다."));
+    }
 
     public Product insertProduct(ProductInsertDto dto, Users seller) {
         // 카테고리 검증: categoryName으로 조회

--- a/src/main/resources/static/css/ban.css
+++ b/src/main/resources/static/css/ban.css
@@ -70,7 +70,7 @@
     display: flex;
     justify-content: center;
     gap: 5px;
-    margin-top: 20px;
+    margin-top: 10px;
 }
 
 .pagination button {

--- a/src/main/resources/static/css/buy.css
+++ b/src/main/resources/static/css/buy.css
@@ -65,7 +65,7 @@
     display: flex;
     justify-content: center;
     gap: 5px;
-    margin-top: 20px;
+    margin-top: 10px;
 }
 
 .pagination button {

--- a/src/main/resources/static/css/cash.css
+++ b/src/main/resources/static/css/cash.css
@@ -313,6 +313,17 @@ dialog::backdrop {
     cursor: pointer;
 }
 
+/* 🌟 추가: 에러 메시지 스타일 */
+.error-msg {
+    color: red;
+    font-size: 14px;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    text-align: center;
+    min-height: 30px;
+    visibility: hidden;
+}
+
 .custom-alert {
     display: none; /* 기본은 숨김 */
     position: fixed;

--- a/src/main/resources/static/css/cash.css
+++ b/src/main/resources/static/css/cash.css
@@ -167,6 +167,17 @@
     text-align: center;
 }
 
+.total-summary {
+    text-align: right;  /* 오른쪽 정렬 */
+    margin-top: 10px;   /* 테이블과 약간의 간격 */
+    padding-right: 20px; /* 오른쪽 여백 (원하는 만큼 조절) */
+    font-size: 16px;    /* 폰트 크기 */
+    font-weight: bold;  /* 강조 효과 */
+}
+.total-summary p {
+    margin: 0;
+}
+
 /* 테이블 정렬 */
 .cash-table th, .cash-table td {
     vertical-align: middle;
@@ -182,7 +193,7 @@
     display: flex;
     justify-content: center;
     gap: 5px;
-    margin-top: 20px;
+    margin-top: 10px;
 }
 
 .pagination button {

--- a/src/main/resources/static/css/cash.css
+++ b/src/main/resources/static/css/cash.css
@@ -107,6 +107,7 @@
     font-size: 15px;
     text-align: center;
     font-weight: bold;
+    text-decoration: none;
 }
 
 /* 활성화된 버튼 스타일: 검은색 배경, 흰색 글씨 */

--- a/src/main/resources/static/css/cash.css
+++ b/src/main/resources/static/css/cash.css
@@ -313,4 +313,42 @@ dialog::backdrop {
     cursor: pointer;
 }
 
+.custom-alert {
+    display: none; /* 기본은 숨김 */
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5); /* 반투명 배경 */
+    z-index: 3000;
+}
 
+.custom-alert-content {
+    background: #fff;
+    border-radius: 8px;
+    width: 300px;
+    margin: 15% auto; /* 화면 중앙에 오도록 */
+    padding: 20px;
+    text-align: center;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+
+.custom-alert-content p {
+    margin-bottom: 20px;
+    font-size: 16px;
+    color: #333;
+}
+
+.custom-alert-content button {
+    padding: 8px 16px;
+    background-color: #007BFF;
+    border: none;
+    border-radius: 4px;
+    color: #fff;
+    font-size: 14px;
+    cursor: pointer;
+}
+.custom-alert-content button:hover {
+    background-color: #0056b3;
+}

--- a/src/main/resources/static/css/evaluation.css
+++ b/src/main/resources/static/css/evaluation.css
@@ -108,7 +108,7 @@
     display: flex;
     justify-content: center;
     gap: 5px;
-    margin-top: 20px;
+    margin-top: 10px;
 }
 
 .pagination button {

--- a/src/main/resources/static/css/likelist.css
+++ b/src/main/resources/static/css/likelist.css
@@ -80,7 +80,7 @@ a {
 /* 페이지네이션 */
 .pagination {
     justify-content: center;
-    margin-top: 20px;
+    margin-top: 10px;
 }
 
 /* 반응형 설정 */

--- a/src/main/resources/static/css/reported.css
+++ b/src/main/resources/static/css/reported.css
@@ -100,7 +100,7 @@
     display: flex;
     justify-content: center;
     gap: 5px;
-    margin-top: 20px;
+    margin-top: 10px;
 }
 
 .pagination button {

--- a/src/main/resources/static/css/sell.css
+++ b/src/main/resources/static/css/sell.css
@@ -96,7 +96,7 @@
     display: flex;
     justify-content: center;
     gap: 5px;
-    margin-top: 20px;
+    margin-top: 10px;
 }
 
 .pagination button {

--- a/src/main/resources/templates/cash/cash.html
+++ b/src/main/resources/templates/cash/cash.html
@@ -203,7 +203,6 @@
     </main>
 </div>
 
-
 <!-- 충전 모달: 충전 금액 선택 + PortOne 결제 로직 -->
 <dialog id="chargeModal" layout:fragment="dialog">
 
@@ -326,7 +325,28 @@
     </form>
 </dialog>
 
+<!-- Custom Alert Modal Markup -->
+<div id="customAlert" class="custom-alert" layout:fragment="alert">
+    <div class="custom-alert-content">
+        <p id="customAlertMessage"></p>
+        <button id="customAlertOk">확인</button>
+    </div>
+</div>
+
 <script layout:fragment="script" th:inline="javascript">
+
+    // ❌ 추가: Custom Alert 함수 정의 (native alert 대신 사용)
+    function customAlert(message) {
+        const alertBox = document.getElementById("customAlert");
+        const alertMessage = document.getElementById("customAlertMessage");
+        const alertOk = document.getElementById("customAlertOk");
+        alertMessage.textContent = message;
+        alertBox.style.display = "block";
+        alertOk.onclick = function() {
+            alertBox.style.display = "none";
+        }
+    }
+
     // ====== 충전 모달 처리 ======
     const openChargeModalBtn = document.getElementById("openChargeModal");
     const chargeModal = document.getElementById("chargeModal");
@@ -442,7 +462,7 @@
         // 4. 결제 요청
         async function handlePayment() {
             if (item.price <= 0) {
-                alert("충전 금액을 선택해주세요.");
+                customAlert("충전 금액을 선택해주세요.");
                 return;
             }
             setWaitingPayment(true);
@@ -474,7 +494,7 @@
                 setWaitingPayment(false);
                 failMessage.textContent = payment.message;
                 // failDialog.open = true;
-                alert("결제 실패: \n" + payment.message);
+                customAlert("결제 실패: \n" + payment.message);
                 return;
             }
 
@@ -492,12 +512,12 @@
             if (completeResponse.ok) {
                 // 결제 완료
                 // successDialog.open = true;
-                alert("결제 성공!");
+                customAlert("결제 성공!");
                 location.reload();
             } else {
                 const errText = await completeResponse.text();
                 // failMessage.textContent = errText;
-                alert("결제 실패: \n" + errText);
+                customAlert("결제 실패: \n" + errText);
                 // failDialog.open = true;
             }
         }
@@ -567,14 +587,14 @@
 
         // 환급 금액이 사용자가 가진 머니(currentCash)보다 초과하면 안 됨.
         if (amount > currentCash) {
-            alert("환급 신청 금액은 보유한 머니 이하이어야 합니다.");
+            customAlert("환급 신청 금액은 보유한 머니 이하이어야 합니다.");
             return;
         }
 
         const bank = document.getElementById("withdrawBank").value;
         const account = document.getElementById("withdrawAccount").value;
         if(amount <= 0 || bank === "" || account.trim() === "") {
-            alert("모든 항목을 정확히 입력해주세요.");
+            customAlert("모든 항목을 정확히 입력해주세요.");
             return;
         }
         // POST 요청으로 환급 신청
@@ -589,16 +609,16 @@
                 })
             });
             if(response.ok) {
-                alert("환급 요청이 접수되었습니다.");
+                customAlert("환급 요청이 접수되었습니다.");
                 withdrawModal.close();
                 location.reload(); // 내역 갱신 등 필요 시
             } else {
                 const errText = await response.text();
-                alert("환급 요청 실패: " + errText);
+                customAlert("환급 요청 실패: " + errText);
             }
         } catch (error) {
             console.error(error);
-            alert("환급 요청 중 오류가 발생했습니다.");
+            customAlert("환급 요청 중 오류가 발생했습니다.");
         }
     });
 </script>

--- a/src/main/resources/templates/cash/cash.html
+++ b/src/main/resources/templates/cash/cash.html
@@ -24,7 +24,7 @@
             <div class="cash-box">
                 <p class="cash-title"> SSAUC 머니 ></p>
                 <div class="cash-box-content">
-                    <h2 class="cash-amount" th:text="${T(java.lang.String).format('%,d 원', session.user.cash)}">0 원</h2>
+                    <h2 class="cash-amount" th:text="${T(java.lang.String).format('%,d 원', user.cash)}">0 원</h2>
                     <div class="cash-buttons">
                         <button class="charge" id="openChargeModal">충전</button>
                         <button class="refund">환급</button>
@@ -274,7 +274,7 @@
     <h2> 환급 신청 </h2>
     <div class="refund-cash-info">
         현재 보유 중인 머니:
-        <span id="currentCashRefund" th:text="${T(java.lang.String).format('%,d 원', session.user.cash)}">0 원</span>
+        <span id="currentCashRefund" th:text="${T(java.lang.String).format('%,d 원', user.cash)}">0 원</span>
     </div>
     <div class="withdraw-info">
         이번 달 환급 횟수:

--- a/src/main/resources/templates/cash/cash.html
+++ b/src/main/resources/templates/cash/cash.html
@@ -89,6 +89,9 @@
                 </tr>
                 </tbody>
             </table>
+            <div class="total-summary">
+                <p>기간 내 결제 금액: <span th:text="${T(java.lang.String).format('%,d 원', totalAmount)}">0 원</span></p>
+            </div>
         </div>
         <!-- 정산 내역 테이블 (User == 판매자) -->
         <div th:if="${filter == 'settlement'}">
@@ -112,6 +115,9 @@
                 </tr>
                 </tbody>
             </table>
+            <div class="total-summary">
+                <p>기간 내 정산 금액: <span th:text="${T(java.lang.String).format('%,d 원', totalAmount)}">0 원</span></p>
+            </div>
         </div>
         <!-- 충전 내역 테이블 -->
         <div th:if="${filter == 'charge'}">
@@ -139,6 +145,9 @@
                 </tr>
                 </tbody>
             </table>
+            <div class="total-summary">
+                <p>기간 내 충전 금액: <span th:text="${T(java.lang.String).format('%,d 원', totalAmount)}">0 원</span></p>
+            </div>
         </div>
         <!-- 환급 내역 테이블 -->
         <div th:if="${filter == 'withdraw'}">
@@ -164,8 +173,10 @@
                 </tr>
                 </tbody>
             </table>
+            <div class="total-summary">
+                <p>기간 내 환급 금액: <span th:text="${T(java.lang.String).format('%,d 원', totalAmount)}">0 원</span></p>
+            </div>
         </div>
-
 
 
         <!-- 페이지네이션 -->

--- a/src/main/resources/templates/cash/cash.html
+++ b/src/main/resources/templates/cash/cash.html
@@ -55,14 +55,94 @@
                 <!-- 결제/정산은 나중 처리 -->
                 <a th:href="@{/cash/cash(filter='calculate')}" class="filter-btn"
                    th:classappend="${filter=='calculate'} ? ' active' : ''">결제 / 정산</a>
+                <!-- 결제 (구매) 내역 -->
+                <a th:href="@{/cash/cash(filter='payment')}" class="filter-btn"
+                   th:classappend="${filter=='payment'} ? ' active' : ''">결제</a>
+                <!-- 정산 (판매) 내역 -->
+                <a th:href="@{/cash/cash(filter='settlement')}" class="filter-btn"
+                   th:classappend="${filter=='settlement'} ? ' active' : ''">정산</a>
+                <!-- 충전 내역 -->
                 <a th:href="@{/cash/cash(filter='charge')}" class="charge filter-btn"
                    th:classappend="${filter=='charge'} ? ' active' : ''">충전</a>
+                <!-- 환급 내역 -->
                 <a th:href="@{/cash/cash(filter='withdraw')}" class="refund filter-btn"
                    th:classappend="${filter=='withdraw'} ? ' active' : ''">환급</a>
             </div>
         </div>
 
-        <!-- 내역 테이블: filter 값에 따라 다른 테이블 출력 -->
+        <!-- 결제/정산 내역 테이블 -->
+        <div th:if="${filter == 'calculate'}">
+            <table class="cash-table">
+                <thead>
+                <tr>
+                    <th>결제/정산 ID</th>
+                    <th>거래 상품명</th>
+                    <th>결제/정산 금액</th>
+                    <th>결제/정산 시간</th>
+                    <th>결제/정산 상태</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="calculate : ${calculateList}">
+                    <td th:text="${calculate.orderId}">1</td>
+                    <td th:text="${calculate.productName}">상품명</td>
+                    <td th:text="${(calculate.paymentAmount.substring(0,1)) +
+               T(java.lang.String).format('%,d', T(java.lang.Long).parseLong(calculate.paymentAmount.substring(1)))}">
+                        +1,600,000
+                    </td>
+                    <td th:text="${#temporals.format(calculate.paymentTime, 'yyyy-MM-dd HH:mm')}">2025-02-26 10:30</td>
+                    <td th:text="${calculate.orderStatus}">완료</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!-- 결제 내역 테이블 (User == 구매자) -->
+        <div th:if="${filter == 'payment'}">
+            <table class="cash-table">
+                <thead>
+                <tr>
+                    <th>결제 ID</th>
+                    <th>상품명</th>
+                    <th>결제 금액</th>
+                    <th>결제 시간</th>
+                    <th>상태</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="calculate : ${calculateList}">
+                    <td th:text="${calculate.orderId}">1</td>
+                    <td th:text="${calculate.productName}">상품명</td>
+                    <td th:text="${calculate.paymentAmount}">-1,000,000</td>
+                    <td th:text="${#temporals.format(calculate.paymentTime, 'yyyy-MM-dd HH:mm')}">2025-02-26 10:30</td>
+                    <td th:text="${calculate.orderStatus}">완료</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!-- 정산 내역 테이블 (User == 판매자) -->
+        <div th:if="${filter == 'settlement'}">
+            <table class="cash-table">
+                <thead>
+                <tr>
+                    <th>정산 ID</th>
+                    <th>상품명</th>
+                    <th>정산 금액</th>
+                    <th>정산 시간</th>
+                    <th>상태</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="calculate : ${calculateList}">
+                    <td th:text="${calculate.orderId}">1</td>
+                    <td th:text="${calculate.productName}">상품명</td>
+                    <td th:text="${calculate.paymentAmount}">+1,000,000</td>
+                    <td th:text="${#temporals.format(calculate.paymentTime, 'yyyy-MM-dd HH:mm')}">2025-02-26 10:30</td>
+                    <td th:text="${calculate.orderStatus}">완료</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!-- 충전 내역 테이블 -->
         <div th:if="${filter == 'charge'}">
             <table class="cash-table">
                 <thead>
@@ -89,7 +169,7 @@
                 </tbody>
             </table>
         </div>
-
+        <!-- 환급 내역 테이블 -->
         <div th:if="${filter == 'withdraw'}">
             <table class="cash-table">
                 <thead>
@@ -115,32 +195,7 @@
             </table>
         </div>
 
-        <!-- 결제/정산: 아직 미구현 -->
-        <div th:if="${filter == 'calculate'}">
-            <table class="cash-table">
-                <thead>
-                <tr>
-                    <th>결제/정산 ID</th>
-                    <th>거래 상품명</th>
-                    <th>결제/정산 금액</th>
-                    <th>결제/정산 시간</th>
-                    <th>결제/정산 상태</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr th:each="calculate : ${calculateList}">
-                    <td th:text="${calculate.orderId}">1</td>
-                    <td th:text="${calculate.productName}">상품명</td>
-                    <td th:text="${(calculate.paymentAmount.substring(0,1)) +
-               T(java.lang.String).format('%,d', T(java.lang.Long).parseLong(calculate.paymentAmount.substring(1)))}">
-                        +1,600,000
-                    </td>
-                    <td th:text="${#temporals.format(calculate.paymentTime, 'yyyy-MM-dd HH:mm')}">2025-02-26 10:30</td>
-                    <td th:text="${calculate.orderStatus}">완료</td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
+
 
         <!-- 페이지네이션 -->
         <div class="pagination">

--- a/src/main/resources/templates/cash/cash.html
+++ b/src/main/resources/templates/cash/cash.html
@@ -90,7 +90,7 @@
                 </tbody>
             </table>
             <div class="total-summary">
-                <p>기간 내 결제 금액: <span th:text="${T(java.lang.String).format('%,d 원', totalAmount)}">0 원</span></p>
+                <p>💶 기간 내 결제 금액: <span th:text="${T(java.lang.String).format('%,d 원', totalAmount)}">0 원</span></p>
             </div>
         </div>
         <!-- 정산 내역 테이블 (User == 판매자) -->
@@ -116,7 +116,7 @@
                 </tbody>
             </table>
             <div class="total-summary">
-                <p>기간 내 정산 금액: <span th:text="${T(java.lang.String).format('%,d 원', totalAmount)}">0 원</span></p>
+                <p>💷 기간 내 정산 금액: <span th:text="${T(java.lang.String).format('%,d 원', totalAmount)}">0 원</span></p>
             </div>
         </div>
         <!-- 충전 내역 테이블 -->
@@ -146,7 +146,7 @@
                 </tbody>
             </table>
             <div class="total-summary">
-                <p>기간 내 충전 금액: <span th:text="${T(java.lang.String).format('%,d 원', totalAmount)}">0 원</span></p>
+                <p>💵 기간 내 충전 금액: <span th:text="${T(java.lang.String).format('%,d 원', totalAmount)}">0 원</span></p>
             </div>
         </div>
         <!-- 환급 내역 테이블 -->
@@ -174,7 +174,7 @@
                 </tbody>
             </table>
             <div class="total-summary">
-                <p>기간 내 환급 금액: <span th:text="${T(java.lang.String).format('%,d 원', totalAmount)}">0 원</span></p>
+                <p>💴 기간 내 환급 금액: <span th:text="${T(java.lang.String).format('%,d 원', totalAmount)}">0 원</span></p>
             </div>
         </div>
 
@@ -247,23 +247,10 @@
                     <span id="displayPrice">0원</span>
                 </div>
             </article>
+            <div id="chargeErrorMsg" class="error-msg"></div>
             <button id="checkoutButton" type="submit">충전하기</button>
         </form>
     </main>
-
-    <!-- 실패 다이얼로그 (간단 표시용) -->
-    <dialog id="failDialog">
-        <header><h1>결제 실패</h1></header>
-        <p id="failMessage"></p>
-        <button type="button" class="closeDialog">닫기</button>
-    </dialog>
-
-    <!-- 성공 다이얼로그 (간단 표시용) -->
-    <dialog id="successDialog">
-        <header><h1>결제 성공</h1></header>
-        <p>결제에 성공했습니다.</p>
-        <button type="button" class="closeDialog">닫기</button>
-    </dialog>
 </dialog>
 
 <!-- 환급 모달 -->
@@ -321,6 +308,7 @@
             <label>총 환급 금액:</label>
             <span id="netWithdrawAmount">0원</span>
         </div>
+        <div id="withdrawErrorMsg" class="error-msg"></div>
         <button type="submit" id="withdrawSubmitButton">환급 신청</button>
     </form>
 </dialog>
@@ -335,8 +323,8 @@
 
 <script layout:fragment="script" th:inline="javascript">
 
-    // ❌ 추가: Custom Alert 함수 정의 (native alert 대신 사용)
-    function customAlert(message) {
+    // Custom Alert 함수 정의 (native alert 대신 사용)
+    function customAlert(message, callback) {
         const alertBox = document.getElementById("customAlert");
         const alertMessage = document.getElementById("customAlertMessage");
         const alertOk = document.getElementById("customAlertOk");
@@ -344,6 +332,9 @@
         alertBox.style.display = "block";
         alertOk.onclick = function() {
             alertBox.style.display = "none";
+            if (callback) {
+                callback();
+            }
         }
     }
 
@@ -358,6 +349,7 @@
         chargeModal.showModal();
         // PortOne 결제 로직 실행
         checkout.load();
+        document.getElementById("chargeErrorMsg").style.visibility = "hidden";
     });
 
     closeModalBtn.addEventListener("click", () => {
@@ -370,6 +362,7 @@
         document.getElementById("customAmount").value = "";
         document.getElementById("customAmount").classList.remove("hidden2");
         document.getElementById("displayPrice").textContent = currentCash.toLocaleString() + "원";
+        document.getElementById("chargeErrorMsg").style.visibility = "hidden";
     }
 
     // ====== 충전 모달 안에서 실행 ======
@@ -379,10 +372,7 @@
         const amountSelect = document.getElementById("amountSelect");
         const customAmount = document.getElementById("customAmount");
         const displayPrice = document.getElementById("displayPrice");
-
-        const failDialog = document.getElementById("failDialog");
         const failMessage = document.getElementById("failMessage");
-        const successDialog = document.getElementById("successDialog");
 
         // 1. SDK, API 데이터 로드
         this.load = async () => {
@@ -457,18 +447,20 @@
 
             item.price = baseAmount > 0 ? baseAmount : 0;
             displayPrice.textContent = (currentCash + item.price).toLocaleString() + "원";
+            document.getElementById("chargeErrorMsg").style.visibility = "hidden";
         }
 
         // 4. 결제 요청
         async function handlePayment() {
             if (item.price <= 0) {
-                customAlert("충전 금액을 선택해주세요.");
+                document.getElementById("chargeErrorMsg").innerText = "충전 금액을 선택해주세요.";
+                document.getElementById("chargeErrorMsg").style.visibility = "visible";
                 return;
             }
             setWaitingPayment(true);
 
             // 먼저 모달을 완전히 닫음(숨김)
-            chargeModal.close(); // chargeModal은 모달 dialog 요소
+            chargeModal.close();
 
             // 고유 paymentId
             function randomId() {
@@ -493,8 +485,8 @@
                 // 결제 실패
                 setWaitingPayment(false);
                 failMessage.textContent = payment.message;
-                // failDialog.open = true;
                 customAlert("결제 실패: \n" + payment.message);
+
                 return;
             }
 
@@ -511,14 +503,12 @@
             setWaitingPayment(false);
             if (completeResponse.ok) {
                 // 결제 완료
-                // successDialog.open = true;
-                customAlert("결제 성공!");
-                location.reload();
+                // customAlert에 콜백 함수를 추가하여, 사용자가 확인 버튼을 누른 후에 location.reload()가 실행
+                customAlert("결제 성공!", () => { location.reload(); });
             } else {
                 const errText = await completeResponse.text();
                 // failMessage.textContent = errText;
                 customAlert("결제 실패: \n" + errText);
-                // failDialog.open = true;
             }
         }
 
@@ -541,6 +531,7 @@
     // 환급 버튼 클릭 시 환급 모달 열기
     refundButton.addEventListener("click", () => {
         withdrawModal.showModal();
+        document.getElementById("withdrawErrorMsg").style.visibility = "hidden";
     });
 
     // 모달 닫기 버튼
@@ -553,6 +544,7 @@
         withdrawAmountSelect.value = "custom";
         withdrawCustomAmount.value = "";
         netWithdrawAmountSpan.textContent = "0원";
+        document.getElementById("withdrawErrorMsg").style.visibility = "hidden";
     }
 
     // 환급 금액 선택 변경 이벤트 등록
@@ -573,6 +565,7 @@
         let commission = currentCount >= 3 ? 1000 : 0;
         let net = baseAmount - commission;
         netWithdrawAmountSpan.textContent = net.toLocaleString() + "원";
+        document.getElementById("withdrawErrorMsg").style.visibility = "hidden";
     }
 
     // 환급 신청 폼 제출 처리
@@ -587,14 +580,16 @@
 
         // 환급 금액이 사용자가 가진 머니(currentCash)보다 초과하면 안 됨.
         if (amount > currentCash) {
-            customAlert("환급 신청 금액은 보유한 머니 이하이어야 합니다.");
+            document.getElementById("withdrawErrorMsg").innerText = "환급 신청 금액은 보유한 쏙머니 이하이어야 합니다.";
+            document.getElementById("withdrawErrorMsg").style.visibility = "visible";
             return;
         }
 
         const bank = document.getElementById("withdrawBank").value;
         const account = document.getElementById("withdrawAccount").value;
         if(amount <= 0 || bank === "" || account.trim() === "") {
-            customAlert("모든 항목을 정확히 입력해주세요.");
+            document.getElementById("withdrawErrorMsg").innerText = "모든 항목을 정확히 입력해주세요.";
+            document.getElementById("withdrawErrorMsg").style.visibility = "visible";
             return;
         }
         // POST 요청으로 환급 신청
@@ -609,16 +604,17 @@
                 })
             });
             if(response.ok) {
-                customAlert("환급 요청이 접수되었습니다.");
                 withdrawModal.close();
-                location.reload(); // 내역 갱신 등 필요 시
+                customAlert("환급 요청이 접수되었습니다.", () => { location.reload(); });
             } else {
                 const errText = await response.text();
                 customAlert("환급 요청 실패: " + errText);
             }
         } catch (error) {
+            withdrawModal.close();
+            location.reload(); // 내역 갱신 등 필요 시
             console.error(error);
-            customAlert("환급 요청 중 오류가 발생했습니다.");
+            customAlert("환급 요청 중 오류가 발생했습니다.", () => { location.reload(); });
         }
     });
 </script>

--- a/src/main/resources/templates/cash/cash.html
+++ b/src/main/resources/templates/cash/cash.html
@@ -52,9 +52,6 @@
         <!-- 내역 필터 -->
         <div class="filter-section">
             <div class="filter-buttons">
-                <!-- 결제/정산은 나중 처리 -->
-                <a th:href="@{/cash/cash(filter='calculate')}" class="filter-btn"
-                   th:classappend="${filter=='calculate'} ? ' active' : ''">결제 / 정산</a>
                 <!-- 결제 (구매) 내역 -->
                 <a th:href="@{/cash/cash(filter='payment')}" class="filter-btn"
                    th:classappend="${filter=='payment'} ? ' active' : ''">결제</a>
@@ -70,32 +67,6 @@
             </div>
         </div>
 
-        <!-- 결제/정산 내역 테이블 -->
-        <div th:if="${filter == 'calculate'}">
-            <table class="cash-table">
-                <thead>
-                <tr>
-                    <th>결제/정산 ID</th>
-                    <th>거래 상품명</th>
-                    <th>결제/정산 금액</th>
-                    <th>결제/정산 시간</th>
-                    <th>결제/정산 상태</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr th:each="calculate : ${calculateList}">
-                    <td th:text="${calculate.orderId}">1</td>
-                    <td th:text="${calculate.productName}">상품명</td>
-                    <td th:text="${(calculate.paymentAmount.substring(0,1)) +
-               T(java.lang.String).format('%,d', T(java.lang.Long).parseLong(calculate.paymentAmount.substring(1)))}">
-                        +1,600,000
-                    </td>
-                    <td th:text="${#temporals.format(calculate.paymentTime, 'yyyy-MM-dd HH:mm')}">2025-02-26 10:30</td>
-                    <td th:text="${calculate.orderStatus}">완료</td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
         <!-- 결제 내역 테이블 (User == 구매자) -->
         <div th:if="${filter == 'payment'}">
             <table class="cash-table">
@@ -112,7 +83,7 @@
                 <tr th:each="calculate : ${calculateList}">
                     <td th:text="${calculate.orderId}">1</td>
                     <td th:text="${calculate.productName}">상품명</td>
-                    <td th:text="${calculate.paymentAmount}">-1,000,000</td>
+                    <td th:text="${T(java.lang.String).format('%,d', calculate.paymentAmount)}">50,000</td>
                     <td th:text="${#temporals.format(calculate.paymentTime, 'yyyy-MM-dd HH:mm')}">2025-02-26 10:30</td>
                     <td th:text="${calculate.orderStatus}">완료</td>
                 </tr>
@@ -135,7 +106,7 @@
                 <tr th:each="calculate : ${calculateList}">
                     <td th:text="${calculate.orderId}">1</td>
                     <td th:text="${calculate.productName}">상품명</td>
-                    <td th:text="${calculate.paymentAmount}">+1,000,000</td>
+                    <td th:text="${T(java.lang.String).format('%,d', calculate.paymentAmount)}">50,000</td>
                     <td th:text="${#temporals.format(calculate.paymentTime, 'yyyy-MM-dd HH:mm')}">2025-02-26 10:30</td>
                     <td th:text="${calculate.orderStatus}">완료</td>
                 </tr>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -208,7 +208,9 @@
 <!-- 페이지별 스크립트 삽입 영역 추가 -->
 <div layout:fragment="dialog"></div>
 <div layout:fragment="dialog2"></div>
+<div layout:fragment="alert"></div>
 <div layout:fragment="script"></div>
+
 <!-- Bootstrap JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script>

--- a/src/main/resources/templates/mypage/mypage.html
+++ b/src/main/resources/templates/mypage/mypage.html
@@ -16,9 +16,9 @@
         <!-- 프로필 영역 -->
         <a th:href="@{/mypage}" class="profile">
             <!-- Users Entity의 profileImage 값 사용 -->
-            <img th:src="@{${session.user.profileImage}}" alt="프로필 이미지">
+            <img th:src="@{${user.profileImage}}" alt="프로필 이미지">
             <!-- Users Entity의 userName 값 사용 -->
-            <p class="username" th:text="${session.user.userName}">Username</p>
+            <p class="username" th:text="${user.userName}">Username</p>
         </a>
         <!-- 마이페이지 네비게이션 메뉴 -->
         <nav class="menu">
@@ -56,12 +56,12 @@
             <!-- 신뢰도 박스 -->
             <a th:href="@{/mypage/evaluation}" class="mypage-box trust-score">
                 <p>나의 신뢰도 ></p>
-                <h2 th:text="${session.user.reputation}">100 점</h2>
+                <h2 th:text="${user.reputation}">100 점</h2>
             </a>
             <!-- SSAUC 머니 박스 -->
             <a th:href="@{/cash/cash}" class="mypage-box money">
                 <p>🔨 SSAUC 머니 ></p>
-                <h2 th:text="${T(java.lang.String).format('%,d 원', session.user.cash)}">0 원</h2>
+                <h2 th:text="${T(java.lang.String).format('%,d 원', user.cash)}">0 원</h2>
             </a>
         </div>
 


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 작업 내용 입력 -->

- 충전(결제) 시 Charge 테이블 details에 PG사 응답 정보 pgResponse.ResultMsg 저장.
- 내역에서 충전/정산 따로 볼 수 있게 구분 필터나 영역 나누기.
- 각 필터에 총 금액 기능 구현
- 기간 조회에 따라서도 총 금액 기능 추가
- 세션에 저장된 값 말고 Users 테이블에 저장된 cash값 불러오기
- 최신 내역이 위로 오게 하기
- Alert 창 전체적인 페이지 분위기에 맞게 디자인 (custom) 하기

## 📎 Issue 번호
<!-- closed #번호 -->
#112 
