### PR TITLE
판매 현황 기능 구현

### DIFF
--- a/src/main/java/com/example/ssauc/user/history/controller/HistoryController.java
+++ b/src/main/java/com/example/ssauc/user/history/controller/HistoryController.java
@@ -1,6 +1,10 @@
 package com.example.ssauc.user.history.controller;
 
+import com.example.ssauc.user.bid.dto.CarouselImage;
 import com.example.ssauc.user.history.dto.BanHistoryDto;
+import com.example.ssauc.user.history.dto.SellHistoryCompletedDto;
+import com.example.ssauc.user.history.dto.SellHistoryOngoingDto;
+import com.example.ssauc.user.history.dto.SoldDetailDto;
 import com.example.ssauc.user.history.service.HistoryService;
 import com.example.ssauc.user.login.entity.Users;
 
@@ -9,19 +13,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Controller
 @RequestMapping("history")
 @RequiredArgsConstructor
 public class HistoryController {
 
-    private final HistoryService banHistoryService;
-
     private final HistoryService historyService;
 
+    // ===================== 차단 관리 =====================
     // 차단 내역 페이지: 로그인한 사용자의 차단 내역 조회
     @GetMapping("/ban")
     public String banPage(@RequestParam(defaultValue = "1") int page,
@@ -34,7 +41,7 @@ public class HistoryController {
         model.addAttribute("user", latestUser);
         // 페이지 번호는 0부터 시작하므로 (page - 1)로 변환
         Pageable pageable = PageRequest.of(page - 1, 10);
-        Page<BanHistoryDto> banPage = banHistoryService.getBanListForUser(latestUser.getUserId(), pageable);
+        Page<BanHistoryDto> banPage = historyService.getBanListForUser(latestUser.getUserId(), pageable);
         model.addAttribute("banList", banPage.getContent());
         model.addAttribute("currentPage", page);
         model.addAttribute("totalPages", banPage.getTotalPages());
@@ -52,10 +59,11 @@ public class HistoryController {
         Users latestUser = historyService.getCurrentUser(user.getUserId());
         model.addAttribute("user", latestUser);
 
-        banHistoryService.unbanUser(banId, latestUser.getUserId());
+        historyService.unbanUser(banId, latestUser.getUserId());
         return "redirect:/history/ban";
     }
 
+    // ===================== 리뷰 관리 =====================
     @GetMapping("/reported")  // 리뷰 내역 페이지로 이동
     public String reportedPage(HttpSession session, Model model) {
         Users user = (Users) session.getAttribute("user");
@@ -64,22 +72,72 @@ public class HistoryController {
         return "/history/reported";
     }
 
+    // ===================== 판매 내역 =====================
     @GetMapping("/sell")  // 판매 현황 리스트 페이지로 이동
-    public String sellPage(HttpSession session, Model model) {
+    public String sellPage(@RequestParam(value = "filter", required = false, defaultValue = "ongoing") String filter,
+                           @RequestParam(value = "page", required = false, defaultValue = "1") int page,
+                           HttpSession session, Model model) {
         Users user = (Users) session.getAttribute("user");
+        if (user == null) {
+            return "redirect:/login";
+        }
         Users latestUser = historyService.getCurrentUser(user.getUserId());
         model.addAttribute("user", latestUser);
+
+        int pageSize = 10;
+        if ("ongoing".equals(filter)) {
+            Pageable pageable = PageRequest.of(page - 1, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<SellHistoryOngoingDto> ongoingPageData = historyService.getOngoingSellHistoryPage(latestUser, pageable);
+            model.addAttribute("list", ongoingPageData.getContent());
+            model.addAttribute("totalPages", ongoingPageData.getTotalPages());
+        } else if ("ended".equals(filter)) {
+            // 판매 마감 리스트: 판매중 상태에서 (경매 마감 시간 + 30분) < 현재 시간인 상품
+            Pageable pageable = PageRequest.of(page - 1, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<SellHistoryOngoingDto> endedPageData = historyService.getEndedSellHistoryPage(latestUser, pageable);
+            model.addAttribute("list", endedPageData.getContent());
+            model.addAttribute("totalPages", endedPageData.getTotalPages());
+        } else if ("completed".equals(filter)) {
+            Pageable pageable = PageRequest.of(page - 1, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<SellHistoryCompletedDto> completedPageData = historyService.getCompletedSellHistoryPage(latestUser, pageable);
+            model.addAttribute("list", completedPageData.getContent());
+            model.addAttribute("totalPages", completedPageData.getTotalPages());
+        }
+        model.addAttribute("currentPage", page);
+        model.addAttribute("filter", filter);
         return "/history/sell";
     }
 
     @GetMapping("/sold")  // 판매 현황 상세 페이지로 이동
-    public String soldPage(HttpSession session, Model model) {
+    public String soldPage(@RequestParam("id") Long productId, HttpSession session, Model model) {
         Users user = (Users) session.getAttribute("user");
+        if (user == null) {
+            return "redirect:/login";
+        }
         Users latestUser = historyService.getCurrentUser(user.getUserId());
         model.addAttribute("user", latestUser);
+
+        // 상품 및 주문 상세 정보 조회 (SoldDetailDto를 이용)
+        SoldDetailDto soldDetail = historyService.getSoldDetailByProductId(productId);
+        model.addAttribute("soldDetail", soldDetail);
+
+        // imageUrl을 쉼표로 분리하여 CarouselImage 리스트 생성 (BidService와 유사한 로직)
+        String imageUrlStr = soldDetail.getImageUrl();  // SoldDetailDto의 imageUrl 필드 (쉼표로 구분된 문자열)
+        String[] urls = imageUrlStr.split(",");
+        List<CarouselImage> carouselImages = new ArrayList<>();
+        int i = 1;
+        for (String url : urls) {
+            CarouselImage image = new CarouselImage();
+            image.setUrl(url.trim());
+            image.setAlt("Slide " + i);
+            i++;
+            carouselImages.add(image);
+        }
+        model.addAttribute("carouselImages", carouselImages);
+
         return "/history/sold";
     }
 
+    // ===================== 구매 내역 =====================
     @GetMapping("/buy")  // 구매 현황 리스트 페이지로 이동
     public String buyPage(HttpSession session, Model model) {
         Users user = (Users) session.getAttribute("user");

--- a/src/main/java/com/example/ssauc/user/history/dto/SellHistoryCompletedDto.java
+++ b/src/main/java/com/example/ssauc/user/history/dto/SellHistoryCompletedDto.java
@@ -1,0 +1,19 @@
+package com.example.ssauc.user.history.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SellHistoryCompletedDto {
+    private Long orderId;
+    private Long productId;
+    private String productName;
+    private String buyerName;
+    private Long totalPrice;
+    private LocalDateTime orderDate;
+    private LocalDateTime completedDate;
+}

--- a/src/main/java/com/example/ssauc/user/history/dto/SellHistoryOngoingDto.java
+++ b/src/main/java/com/example/ssauc/user/history/dto/SellHistoryOngoingDto.java
@@ -1,0 +1,18 @@
+package com.example.ssauc.user.history.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SellHistoryOngoingDto {
+    private Long productId;
+    private String productName;
+    private Long tempPrice;
+    private Long price;
+    private LocalDateTime createdAt;
+    private LocalDateTime endAt;
+}

--- a/src/main/java/com/example/ssauc/user/history/dto/SoldDetailDto.java
+++ b/src/main/java/com/example/ssauc/user/history/dto/SoldDetailDto.java
@@ -1,0 +1,31 @@
+package com.example.ssauc.user.history.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+public class SoldDetailDto {
+    // Product 테이블 관련 필드
+    private String productName;
+    private Long startPrice;
+    private LocalDateTime createdAt;
+    private int dealType;
+    private String imageUrl;
+
+    // Orders 테이블 관련 필드
+    private Long orderId;
+    private String buyerName;
+    private Long totalPrice;
+    private String recipientName;
+    private String recipientPhone;
+    private String postalCode;
+    private String deliveryAddress;
+    private LocalDateTime orderDate;
+    private LocalDateTime completedDate;
+}
+

--- a/src/main/java/com/example/ssauc/user/history/service/HistoryService.java
+++ b/src/main/java/com/example/ssauc/user/history/service/HistoryService.java
@@ -3,20 +3,30 @@ package com.example.ssauc.user.history.service;
 import com.example.ssauc.user.chat.entity.Ban;
 import com.example.ssauc.user.history.dto.BanHistoryDto;
 import com.example.ssauc.user.chat.repository.BanRepository;
+import com.example.ssauc.user.history.dto.SellHistoryCompletedDto;
+import com.example.ssauc.user.history.dto.SellHistoryOngoingDto;
+import com.example.ssauc.user.history.dto.SoldDetailDto;
 import com.example.ssauc.user.login.entity.Users;
 import com.example.ssauc.user.login.repository.UsersRepository;
+import com.example.ssauc.user.order.entity.Orders;
+import com.example.ssauc.user.order.repository.OrdersRepository;
+import com.example.ssauc.user.product.entity.Product;
+import com.example.ssauc.user.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class HistoryService {
 
     private final UsersRepository usersRepository;
-
+    private final ProductRepository productRepository;
+    private final OrdersRepository ordersRepository;
     private final BanRepository banRepository;
 
     // 세션에서 전달된 userId를 이용하여 DB에서 최신 사용자 정보를 조회합니다.
@@ -25,6 +35,7 @@ public class HistoryService {
                 .orElseThrow(() -> new RuntimeException("사용자 정보가 없습니다."));
     }
 
+    // ===================== 차단 관리 =====================
     @Transactional(readOnly = true)
     public Page<BanHistoryDto> getBanListForUser(Long userId, Pageable pageable) {
         Page<Ban> bans = banRepository.findByUserUserId(userId, pageable);
@@ -44,5 +55,85 @@ public class HistoryService {
             throw new IllegalArgumentException("차단 해제 권한이 없습니다.");
         }
         banRepository.delete(ban);
+    }
+
+    // ===================== 판매 내역 =====================
+    // 판매중 리스트
+    @Transactional(readOnly = true)
+    public Page<SellHistoryOngoingDto> getOngoingSellHistoryPage(Users seller, Pageable pageable) {
+        // 판매중 리스트: 경매 마감 시간에 10분을 더한 값이 현재 시간보다 아직 지나지 않은 상품
+        // 즉, 상품의 endAt >= (현재 시간 - 10분)인 경우만 포함
+        LocalDateTime cutoff = LocalDateTime.now().minusMinutes(10);
+        Page<Product> productsPage = productRepository.findBySellerAndStatusAndEndAtGreaterThanEqual(seller, "판매중", cutoff, pageable);
+        return productsPage.map(p -> new SellHistoryOngoingDto(
+                p.getProductId(),
+                p.getName(),
+                p.getTempPrice(),
+                p.getPrice(),
+                p.getCreatedAt(),
+                p.getEndAt()
+        ));
+    }
+    // 판매 마감 리스트
+    @Transactional(readOnly = true)
+    public Page<SellHistoryOngoingDto> getEndedSellHistoryPage(Users seller, Pageable pageable) {
+        // 판매 마감 리스트: 판매중 상태에서 (경매 마감 시간 + 10분)이 이미 지난 상품
+        // 즉, 상품의 endAt < (현재 시간 - 10분)인 경우
+        LocalDateTime cutoff = LocalDateTime.now().minusMinutes(10);
+        Page<Product> productsPage = productRepository.findBySellerAndStatusAndEndAtBefore(seller, "판매중", cutoff, pageable);
+        return productsPage.map(p -> new SellHistoryOngoingDto(
+                p.getProductId(),
+                p.getName(),
+                p.getTempPrice(),
+                p.getPrice(),
+                p.getCreatedAt(),
+                p.getEndAt()
+        ));
+    }
+    // 판매 완료 리스트
+    @Transactional(readOnly = true)
+    public Page<SellHistoryCompletedDto> getCompletedSellHistoryPage(Users seller, Pageable pageable) {
+        Page<Product> productsPage = productRepository.findBySellerAndStatus(seller, "판매완료", pageable);
+        return productsPage.map(p -> {
+            // 판매 완료된 상품의 주문 정보는 보통 하나가 존재한다고 가정합니다.
+            Orders order = p.getOrders().stream().findFirst()
+                    .orElseThrow(() -> new RuntimeException("판매 완료 상품에 주문 정보가 없습니다."));
+            return new SellHistoryCompletedDto(
+                    order.getOrderId(),
+                    p.getProductId(),
+                    p.getName(),
+                    order.getBuyer().getUserName(),
+                    order.getTotalPrice(),
+                    order.getOrderDate(),
+                    order.getCompletedDate()
+            );
+        });
+    }
+
+    // 판매 완료 상세 내역
+    @Transactional(readOnly = true)
+    public SoldDetailDto getSoldDetailByProductId(Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new RuntimeException("해당 상품이 존재하지 않습니다."));
+
+        Orders order = product.getOrders().stream().findFirst()
+                .orElseThrow(() -> new RuntimeException("해당 상품의 주문 정보가 없습니다."));
+
+        return SoldDetailDto.builder()
+                .productName(product.getName())
+                .startPrice(product.getStartPrice())
+                .createdAt(product.getCreatedAt())
+                .dealType(product.getDealType())
+                .imageUrl(product.getImageUrl())
+                .orderId(order.getOrderId())
+                .buyerName(order.getBuyer().getUserName())
+                .totalPrice(order.getTotalPrice())
+                .recipientName(order.getRecipientName())
+                .recipientPhone(order.getRecipientPhone())
+                .postalCode(order.getPostalCode())
+                .deliveryAddress(order.getDeliveryAddress())
+                .orderDate(order.getOrderDate())
+                .completedDate(order.getCompletedDate())
+                .build();
     }
 }

--- a/src/main/java/com/example/ssauc/user/order/repository/OrdersRepository.java
+++ b/src/main/java/com/example/ssauc/user/order/repository/OrdersRepository.java
@@ -46,5 +46,6 @@ public interface OrdersRepository extends JpaRepository<Orders, Long> {
                                                       @Param("start") LocalDateTime start,
                                                       @Param("end") LocalDateTime end);
 
-
+    // 주문 상태가 "거래완료"인 주문 페이징 처리
+    Page<Orders> findBySellerAndOrderStatus(Users seller, String orderStatus, Pageable pageable);
 }

--- a/src/main/java/com/example/ssauc/user/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/ssauc/user/product/repository/ProductRepository.java
@@ -1,11 +1,16 @@
 package com.example.ssauc.user.product.repository;
 
+import com.example.ssauc.user.login.entity.Users;
 import com.example.ssauc.user.product.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
@@ -13,4 +18,12 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Modifying
     @Query("update Product p set p.status = '판매완료' where p.productId = :productId")
     void completeSell(@Param("productId") Long productId);
+
+    Page<Product> findBySellerAndStatus(Users seller, String status, Pageable pageable);
+
+    // 판매중 상태의 상품 중, 경매 마감 시간이 cutoff 이상인 항목 (판매중 리스트)
+    Page<Product> findBySellerAndStatusAndEndAtGreaterThanEqual(Users seller, String status, LocalDateTime cutoff, Pageable pageable);
+    // 판매중 상태의 상품 중, 경매 마감 시간이 cutoff 미만인 항목 (판매 마감 리스트)
+    Page<Product> findBySellerAndStatusAndEndAtBefore(Users seller, String status, LocalDateTime cutoff, Pageable pageable);
+
 }

--- a/src/main/resources/static/css/sell.css
+++ b/src/main/resources/static/css/sell.css
@@ -47,6 +47,7 @@
     font-size: 15px;
     text-align: center;
     font-weight: bold;
+    text-decoration: none;
 }
 
 .filter-btn.active {

--- a/src/main/resources/static/css/sold.css
+++ b/src/main/resources/static/css/sold.css
@@ -59,18 +59,20 @@
 }
 
 /* 상품 이미지 (오른쪽) */
-.product-image {
-    width: 200px;
+/* 캐러셀 전체 영역 및 각 슬라이드의 고정 높이 설정 */
+.carousel-inner,
+.carousel-item {
     height: 200px;
-    border: 1px solid #ddd;
-    border-radius: 10px;
-    overflow: hidden;
+    width: 200px;
+
 }
 
-.product-image img {
+/* 캐러셀 슬라이드 이미지 스타일 */
+.carousel-item img {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    display: block;
 }
 
 /* 거래 정보 영역 */
@@ -78,7 +80,6 @@
     font-size: 16px;
     line-height: 1.5;
     border-top: 1px solid #eee;
-    padding-top: 20px;
     color: #000;
 }
 
@@ -89,6 +90,11 @@
 .transaction-info strong {
     display: inline-block;
     margin-right: 5px;
+}
+
+.product-info, .transaction-info {
+    padding: 20px;
+    background-color: #F8F9FA;
 }
 
 /* 운송장 등록 영역 */

--- a/src/main/resources/templates/history/sell.html
+++ b/src/main/resources/templates/history/sell.html
@@ -23,89 +23,95 @@
         <!-- 필터 섹션 -->
         <div class="filter-section">
             <div class="filter-buttons">
-                <button class="filter-btn active" onclick="setActiveFilter(this, 'ongoing')">판매중 리스트</button>
-                <button class="filter-btn" onclick="setActiveFilter(this, 'completed')">판매 완료 리스트</button>
+                <a th:href="@{/history/sell(filter='ongoing', page=${currentPage})}"
+                   class="filter-btn" th:classappend="${filter=='ongoing'} ? ' active' : ''">
+                    판매중
+                </a>
+                <a th:href="@{/history/sell(filter='ended', page=${currentPage})}"
+                   class="filter-btn" th:classappend="${filter=='ended'} ? ' active' : ''">
+                    판매 마감
+                </a>
+                <a th:href="@{/history/sell(filter='completed', page=${currentPage})}"
+                   class="filter-btn" th:classappend="${filter=='completed'} ? ' active' : ''">
+                    판매 완료
+                </a>
             </div>
         </div>
 
-        <!-- 탭 콘텐츠: 판매중 리스트 (기본 노출) -->
-        <div class="tab-content" id="ongoing">
+        <!-- 판매중 리스트 (기본 노출) -->
+        <div th:if="${filter=='ongoing' || filter=='ended'}">
+            <table class="sell-table">
+                <thead>
+                <tr>
+                    <th>상품 이름</th>
+                    <th>현재 가격</th>
+                    <th>즉시 구매가</th>
+                    <th>등록 시간</th>
+                    <th>경매 마감 시간</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="item : ${list}"
+                    th:onclick="|location.href='/bid/bid?productId=' + ${item.productId}|"
+                    style="cursor: pointer;">
+                    <td th:text="${item.productName}">상품 A</td>
+                    <td th:text="${item.tempPrice}">10000</td>
+                    <td th:text="${item.price}">15000</td>
+                    <td th:text="${#temporals.format(item.createdAt, 'yyyy-MM-dd HH:mm')}">2025-02-05 14:30:00</td>
+                    <td th:text="${#temporals.format(item.endAt, 'yyyy-MM-dd HH:mm')}">2025-02-06 14:30:00</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- 판매 완료 리스트 -->
+        <div th:if="${filter=='completed'}">
             <table class="sell-table">
                 <thead>
                 <tr>
                     <th>상품 이름</th>
                     <th>구매자</th>
-                    <th>등록 시간</th>
+                    <th>판매 가격</th>
                     <th>판매 시간</th>
+                    <th>거래 완료 시간</th>
                 </tr>
                 </thead>
                 <tbody>
-                <tr onclick="location.href='/product/ongoingDetail?id=1'">
-                    <td>상품 A</td>
-                    <td></td>
-                    <td>2025-02-05 14:30:00</td>
-                    <td></td>
+                <tr th:each="item : ${list}"
+                    th:onclick="|location.href='/history/sold?id=' + ${item.productId}|"
+                    style="cursor: pointer;">
+                    <td th:text="${item.productName}">상품 B</td>
+                    <td th:text="${item.buyerName}">구매자123</td>
+                    <td th:text="${item.totalPrice}">20000</td>
+                    <td th:text="${#temporals.format(item.orderDate, 'yyyy-MM-dd HH:mm')}">2025-02-04 10:20:00</td>
+                    <td th:text="${#temporals.format(item.completedDate, 'yyyy-MM-dd HH:mm')}">2025-02-06 16:45:00</td>
                 </tr>
-                <!-- 추가 행: 백엔드 연동에 따라 동적으로 채워짐 -->
                 </tbody>
             </table>
         </div>
 
-        <!-- 탭 콘텐츠: 판매 완료 리스트 -->
-        <div class="tab-content" id="completed" style="display: none;">
-            <table class="sell-table">
-                <thead>
-                <tr>
-                    <th>상품 이름</th>
-                    <th>구매자</th>
-                    <th>등록 시간</th>
-                    <th>판매 시간</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr onclick="location.href='/product/completedDetail?id=2'">
-                    <td>상품 B</td>
-                    <td>구매자123</td>
-                    <td>2025-02-04 10:20:00</td>
-                    <td>2025-02-06 16:45:00</td>
-                </tr>
-                <!-- 추가 행: 백엔드 연동에 따라 동적으로 채워짐 -->
-                </tbody>
-            </table>
-        </div>
-
-        <!-- 페이지네이션 -->
+        <!-- 페이지네이션 (filter와 page 파라미터 활용) -->
         <div class="pagination">
-            <button><</button>
-            <button class="active">1</button>
-            <button>2</button>
-            <button>3</button>
-            <button>4</button>
-            <button>5</button>
-            <button>></button>
+            <a th:if="${currentPage > 1}"
+               th:href="@{/history/sell(filter=${filter}, page=${currentPage - 1})}">
+                <button>&lt;</button>
+            </a>
+            <span th:each="i : ${#numbers.sequence(1, totalPages)}">
+        <a th:href="@{/history/sell(filter=${filter}, page=${i})}">
+            <button th:text="${i}" th:classappend="${i == currentPage} ? ' active' : ''"></button>
+        </a>
+            </span>
+            <a th:if="${currentPage < totalPages}"
+               th:href="@{/history/sell(filter=${filter}, page=${currentPage + 1})}">
+                <button>&gt;</button>
+            </a>
         </div>
+
     </main>
 </div>
 
-<!-- 필터 버튼 전환 스크립트 -->
-<script>
-    function setActiveFilter(selectedButton, tabId) {
-        // 모든 버튼에서 active 클래스를 제거
-        const buttons = document.querySelectorAll(".filter-btn");
-        buttons.forEach(button => {
-            button.classList.remove("active");
-        });
-        // 클릭한 버튼에 active 추가
-        selectedButton.classList.add("active");
+<script layout:fragment="script">
 
-        // 모든 탭 숨김
-        const tabContents = document.querySelectorAll(".tab-content");
-        tabContents.forEach(tab => {
-            tab.style.display = "none";
-        });
-        // 선택한 탭 보이기
-        document.getElementById(tabId).style.display = "block";
-    }
 </script>
 
 </body>

--- a/src/main/resources/templates/history/sold.html
+++ b/src/main/resources/templates/history/sold.html
@@ -3,68 +3,122 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="layout.html">
 <head>
-  <meta charset="UTF-8">
-  <title>판매 내역 상세</title>
-  <!-- 스타일시트 연결 -->
-  <link rel="stylesheet" href="/css/mypage.css">
-  <link rel="stylesheet" href="/css/sold.css">
+    <meta charset="UTF-8">
+    <title>판매 내역 상세</title>
+    <!-- 스타일시트 연결 -->
+    <link rel="stylesheet" href="/css/mypage.css">
+    <link rel="stylesheet" href="/css/sold.css">
 </head>
 <body>
 
 <div class="selled-container" layout:fragment="content">
-  <!-- 왼쪽 사이드바 (mypage와 동일) -->
-  <div th:replace="~{mypage/mypage :: sidebar}"></div>
+    <!-- 왼쪽 사이드바 (mypage와 동일) -->
+    <div th:replace="~{mypage/mypage :: sidebar}"></div>
 
-  <!-- 메인 컨텐츠 -->
-  <main class="selled-main">
-    <h2>판매 내역 상세</h2>
-    <div class="sell-detail">
-      <!-- 상품 정보 영역 -->
-      <div class="product-info">
-        <!-- 왼쪽: 상품 정보 -->
-        <div class="product-details">
-          <p class="product-name"><strong>상품 이름:</strong> <span>상품 A</span></p>
-          <p class="product-category"><strong>카테고리:</strong> <span>전자제품</span></p>
-          <p class="register-time"><strong>등록 시간:</strong> <span>2025-02-05 14:30:00</span></p>
-        </div>
-        <!-- 오른쪽: 상품 이미지 -->
-        <div class="product-image">
-          <img src="/images/sample_product.jpg" alt="상품 이미지">
-        </div>
-      </div>
+    <!-- 메인 컨텐츠 -->
+    <main class="selled-main">
+        <h2>판매 내역 상세</h2>
+        <div class="sell-detail">
+            <!-- 상품 정보 영역 -->
+            <div class="product-info">
+                <!-- 왼쪽: 상품 정보 -->
+                <div class="product-details">
+                    <p class="product-name">
+                        <strong>상품 이름:</strong> <span th:text="${soldDetail.productName}">상품 A</span>
+                    </p>
+                    <p class="start-price">
+                        <strong>경매 시작가:</strong> <span th:text="${soldDetail.startPrice}">10000</span>
+                    </p>
+                    <p class="register-time">
+                        <strong>등록 시간:</strong> <span
+                            th:text="${#temporals.format(soldDetail.createdAt, 'yyyy-MM-dd HH:mm:ss')}">2025-02-05 14:30:00</span>
+                    </p>
+                    <p class="deal-type">
+                        <strong>거래 방식:</strong>
+                        <span th:text="${soldDetail.dealType == 0 ? '🧑🏻 직거래' : (soldDetail.dealType == 1 ? '🚚 택배거래' : '🧑🏻🚚 직거래, 택배거래')}">거래 방식</span>
+                    </p>
+                </div>
+                <!-- 오른쪽: 상품 이미지 (Carousel로 최대 5개 이미지 표시) -->
+                <div id="carouselSold" class="carousel slide" data-bs-ride="carousel">
+                    <div class="carousel-inner">
+                        <div th:each="image, iterStat : ${carouselImages}"
+                             class="carousel-item"
+                             th:classappend="${iterStat.index == 0} ? ' active' : ''">
+                            <img th:src="@{${image.url}}" class="d-block w-100" th:alt="${image.alt}"/>
+                        </div>
+                    </div>
+                    <button class="carousel-control-prev" type="button" data-bs-target="#carouselSold"
+                            data-bs-slide="prev">
+                        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                        <span class="visually-hidden">이전</span>
+                    </button>
+                    <button class="carousel-control-next" type="button" data-bs-target="#carouselSold"
+                            data-bs-slide="next">
+                        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                        <span class="visually-hidden">다음</span>
+                    </button>
+                </div>
+            </div>
 
-      <!-- 거래 정보 영역 -->
-      <div class="transaction-info">
-        <p class="buyer"><strong>구매자:</strong> <span>구매자123</span></p>
-        <p class="transaction-type"><strong>거래 방식:</strong> <span>즉시 구매</span></p>
-        <p class="sold-price"><strong>판매 가격:</strong> <span>50,000 원</span></p>
-        <p class="sale-time"><strong>판매 시간:</strong> <span>2025-02-06 16:45:00</span></p>
-
-        <!-- 운송장 등록 영역 -->
-        <div class="tracking">
-          <span class="tracking-label">운송장 등록 현황:</span>
-          <button class="tracking-btn not-registered" onclick="registerTracking()">운송장 등록</button>
-          <p class="tracking-number" style="display: none;">
-            <strong>등록된 운송장 번호:</strong> <span id="trackingNo"></span>
-          </p>
+            <!-- 거래 정보 영역 -->
+            <div class="transaction-info">
+                <p class="buyer">
+                    <strong>구매자:</strong>
+                    <span th:text="${soldDetail.buyerName}">구매자123</span>
+                </p>
+                <p class="sold-price">
+                    <strong>판매가:</strong>
+                    <span th:text="${soldDetail.totalPrice}">50,000 원</span>
+                </p>
+                <p class="sale-time">
+                    <strong>판매 시간:</strong>
+                    <span th:text="${#temporals.format(soldDetail.orderDate, 'yyyy-MM-dd HH:mm:ss')}">2025-02-06 16:45:00</span>
+                </p>
+                <p class="completed-time">
+                    <strong>거래 완료 시간:</strong>
+                    <span th:text="${#temporals.format(soldDetail.completedDate, 'yyyy-MM-dd HH:mm:ss')}">2025-02-06 17:00:00</span>
+                </p>
+                <p class="recipient-name">
+                    <strong>수령인 이름:</strong>
+                    <span th:text="${soldDetail.recipientName}">홍길동</span>
+                </p>
+                <p class="recipient-phone">
+                    <strong>수령인 연락처:</strong>
+                    <span th:text="${soldDetail.recipientPhone}">010-1234-5678</span>
+                </p>
+                <p class="postal-code">
+                    <strong>우편번호:</strong>
+                    <span th:text="${soldDetail.postalCode}">12345</span>
+                </p>
+                <p class="delivery-address">
+                    <strong>배송 주소:</strong>
+                    <span th:text="${soldDetail.deliveryAddress}">서울특별시 강남구 테헤란로 123</span>
+                </p>
+                <!-- 운송장 등록 영역 -->
+                <div class="tracking">
+                    <span class="tracking-label">운송장 등록 현황:</span>
+                    <button class="tracking-btn not-registered" onclick="registerTracking()">운송장 등록</button>
+                    <p class="tracking-number" style="display: none;">
+                        <strong>등록된 운송장 번호:</strong> <span id="trackingNo"></span>
+                    </p>
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
-  </main>
+    </main>
 </div>
 
-<script>
-  function registerTracking() {
-    const trackingNo = prompt("운송장 번호를 입력하세요:");
-    if(trackingNo && trackingNo.trim() !== "") {
-      const btn = document.querySelector('.tracking-btn');
-      btn.classList.remove('not-registered');
-      btn.classList.add('registered');
-      btn.textContent = "운송장 등록 완료";
-      document.getElementById("trackingNo").textContent = trackingNo.trim();
-      document.querySelector(".tracking-number").style.display = "block";
+<script layout:fragment="script">
+    function registerTracking() {
+        const trackingNo = prompt("운송장 번호를 입력하세요:");
+        if (trackingNo && trackingNo.trim() !== "") {
+            const btn = document.querySelector('.tracking-btn');
+            btn.classList.remove('not-registered');
+            btn.classList.add('registered');
+            btn.textContent = "운송장 등록 완료";
+            document.getElementById("trackingNo").textContent = trackingNo.trim();
+            document.querySelector(".tracking-number").style.display = "block";
+        }
     }
-  }
 </script>
 
 </body>


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 작업 내용 입력 -->
- 필터링 기능(판매중, 판매 마감, 판매 완료) 
- '판매중' 리스트 중 경매 마감 시간 기준 10분 지난 항목은 '판매 마감' 리스트로 이동
- '판매중', '판매 마감' 리스트에서 각 항목 클릭 시 해당 상품에 대한 '입찰 페이지(bid.html)'로 이동
- '판매 완료' 리스트에서 각 항목 클릭 시 해당 상품에 대한 '판매 내역 상세 페이지(sold.html)'로 이동
- '판매 내역 상세 페이지'에서 운송장 등록 기능 구현
  - 현재 단순 입력, 팀원들과 상의 후 NCP CLOVA OCR 추가할 수 있음
- 기능 확인 시 DB에 Product와 Orders에 대해 연관성 있는 데이터가 있어야 함

- '판매중', '판매 마감' 리스트에서 표시할 데이터
  - Product 테이블
    - name -- 상품 이름
    - temp_price -- 현재 가격
    - price -- 즉시구매가
    - created_at -- 등록 시간
    - end_at -- 경매 마감 시간
 
- '판매 완료' 리스트에서 표시할 데이터
  - Product 테이블
    - name -- 상품 이름
  - Users 테이블
    - u.user_name -- 구매자(Orders.buyer_id 기준) 
  - Orders 테이블
    - total_price -- 판매 가격
    - order_date -- 판매 시간
    - completed_date -- 거래 완료 시간

- '판매 내역 상세' 페이지에서 표시할 데이터
  - Product 테이블
    - name -- 상품 이름
    - start_price -- 경매 시작가
    - deal_type -- 0: 직거래, 1: 택배, 2: 직거래와 택배
    - image_url -- 이미지 주소
  - Users 테이블
    - u.user_name -- 구매자(Orders.buyer_id 기준) 
  - Orders테이블
    - name -- 상품 이름
    - total_price -- 판매가
    - recipient_name -- 수령인 이름
    - recipient_phone -- 수령인 연락처
    - postal_code -- 우편번호
    - delivery_address -- 배송 주소
    - order_date -- 판매 시간
    - completed_date -- 거래 완료 시간

## 📎 Issue 번호
<!-- closed #번호 -->
#133 