### PR TITLE
신고 내역 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/ssauc/user/bid/repository/ProductReportRepository.java
+++ b/src/main/java/com/example/ssauc/user/bid/repository/ProductReportRepository.java
@@ -1,7 +1,11 @@
 package com.example.ssauc.user.bid.repository;
 
 import com.example.ssauc.user.bid.entity.ProductReport;
+import com.example.ssauc.user.login.entity.Users;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductReportRepository extends JpaRepository<ProductReport, Long> {
+    Page<ProductReport> findByReporter(Users reporter, Pageable pageable);
 }

--- a/src/main/java/com/example/ssauc/user/chat/repository/ReportRepository.java
+++ b/src/main/java/com/example/ssauc/user/chat/repository/ReportRepository.java
@@ -1,7 +1,11 @@
 package com.example.ssauc.user.chat.repository;
 
 import com.example.ssauc.user.chat.entity.Report;
+import com.example.ssauc.user.login.entity.Users;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
+    Page<Report> findByReporter(Users reporter, Pageable pageable);
 }

--- a/src/main/java/com/example/ssauc/user/history/dto/ProductReportDto.java
+++ b/src/main/java/com/example/ssauc/user/history/dto/ProductReportDto.java
@@ -1,0 +1,23 @@
+package com.example.ssauc.user.history.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductReportDto {
+    private Long reportId;
+    private String productName;
+    private String reportReason;
+    private LocalDateTime reportDate;
+    private LocalDateTime processedAt;
+    private String status;
+}

--- a/src/main/java/com/example/ssauc/user/history/dto/ReportDetailDto.java
+++ b/src/main/java/com/example/ssauc/user/history/dto/ReportDetailDto.java
@@ -1,0 +1,28 @@
+package com.example.ssauc.user.history.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportDetailDto {
+    // "product" 또는 "user" 값으로 신고 유형 구분
+    private String type;
+    // 상품 신고인 경우
+    private String productName;
+    // 유저 신고인 경우
+    private String reportedUserName;
+    private String reportReason;
+    private String details;
+    private LocalDateTime reportDate;
+    private String status;
+    private LocalDateTime processedAt;
+}

--- a/src/main/java/com/example/ssauc/user/history/dto/UserReportDto.java
+++ b/src/main/java/com/example/ssauc/user/history/dto/UserReportDto.java
@@ -1,0 +1,23 @@
+package com.example.ssauc.user.history.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserReportDto {
+    private Long reportId;
+    private String reportedUserName;
+    private String reportReason;
+    private LocalDateTime reportDate;
+    private LocalDateTime processedAt;
+    private String status;
+}

--- a/src/main/resources/static/css/mypage.css
+++ b/src/main/resources/static/css/mypage.css
@@ -1,3 +1,22 @@
+/* 마이페이지 하위 페이지들에 적용 */
+.container2 {
+    display: flex;
+    width: 100%;
+    max-width: 1200px;
+    margin: 40px auto;
+    gap: 40px;
+}
+.main2 {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+.main2 h2 {
+    font-size: 24px;
+    font-weight: bold;
+}
+
 /* 마이페이지 전체 컨테이너 */
 .mypage-container {
     display: flex; /* 사이드바와 메인 콘텐츠를 가로 배치 */

--- a/src/main/resources/static/css/report.css
+++ b/src/main/resources/static/css/report.css
@@ -47,6 +47,7 @@
     font-size: 15px;
     text-align: center;
     font-weight: bold;
+    text-decoration: none;
 }
 
 /* 활성화된 버튼 스타일 */
@@ -56,17 +57,17 @@
 }
 
 /* 신고 내역 테이블 */
-.reported-table {
+.report-table {
     width: 100%;
     border-collapse: collapse;
 }
 
-.reported-table thead {
+.report-table thead {
     border-top: 2px solid black;
     border-bottom: 2px solid black;
 }
 
-.reported-table th {
+.report-table th {
     background-color: white;
     color: black;
     font-weight: bold;
@@ -75,23 +76,23 @@
     border-bottom: 2px solid black;
 }
 
-.reported-table td {
+.report-table td {
     padding: 12px;
     text-align: center;
 }
 
 /* 테이블 정렬 */
-.reported-table th, .reported-table td {
+.report-table th, .report-table td {
     vertical-align: middle;
 }
 
 /* 테이블 짝수 행 배경 색상 */
-.reported-table tbody tr:nth-child(even) {
+.report-table tbody tr:nth-child(even) {
     background-color: #f9f9f9;
 }
 
 /* 테이블 행 클릭 시 커서 변경 */
-.reported-table tbody tr {
+.report-table tbody tr {
     cursor: pointer;
 }
 

--- a/src/main/resources/templates/history/bought.html
+++ b/src/main/resources/templates/history/bought.html
@@ -9,10 +9,6 @@
   <link rel="stylesheet" href="/css/mypage.css">
   <script src="/js/smartApiCodes.js"></script>
   <style>
-    .col-md-10 {
-      padding-left: 80px;
-      padding-top: 24px;
-    }
     /* 캐러셀 전체 영역 및 각 슬라이드의 고정 높이 설정 */
     .carousel-inner,
     .carousel-item {
@@ -56,13 +52,12 @@
   </style>
 </head>
 <body>
-<div class="container" layout:fragment="content">
-  <div class="row">
+<div class="container2" layout:fragment="content">
     <!-- 왼쪽 Sidebar (mypage 그대로) -->
     <div class="sidebar" th:replace="~{mypage/mypage :: sidebar}"></div>
     <!-- 오른쪽 메인 컨텐츠 -->
-    <div class="col-md-10">
-      <h2 class="mb-4">구매 내역 상세</h2>
+    <div class="main2">
+      <h2 class="mb-4">구매 상세 내역</h2>
 
       <!-- Section 1 -->
       <div class="card mb-4">
@@ -150,7 +145,6 @@
         <button id="completeBtn" class="complete-btn ms-auto" onclick="completeTransaction()"
                 th:classappend="${boughtDetail.completedDate != null} ? ' completed' : ''">거래 완료</button>
       </div>
-    </div>
   </div>
 </div>
 

--- a/src/main/resources/templates/history/report.html
+++ b/src/main/resources/templates/history/report.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="layout.html">
+<head>
+    <meta charset="UTF-8">
+    <title>신고 내역</title>
+    <!-- 스타일시트 연결 -->
+    <link rel="stylesheet" href="/css/mypage.css">
+    <link rel="stylesheet" href="/css/report.css">
+</head>
+<body>
+
+<div class="reported-container" layout:fragment="content">
+    <!-- 왼쪽 사이드바 (mypage와 동일) -->
+    <div th:replace="~{mypage/mypage :: sidebar}"></div>
+
+    <!-- 메인 컨텐츠 -->
+    <main class="reported-main">
+        <!-- 페이지 제목 -->
+        <h2>신고 내역</h2>
+
+        <!-- 필터 섹션 -->
+        <div class="filter-section">
+            <div class="filter-buttons">
+                <a th:href="@{/history/report(filter='product')}"
+                   class="filter-btn" th:classappend="${filter=='product'} ? ' active' : ''">
+                    상품 신고
+                </a>
+                <a th:href="@{/history/report(filter='user')}"
+                   class="filter-btn" th:classappend="${filter=='user'} ? ' active' : ''">
+                    유저 신고
+                </a>
+            </div>
+        </div>
+
+        <!-- 상품 신고 리스트 -->
+        <div th:if="${filter=='product'}">
+            <table class="report-table">
+                <thead>
+                <tr>
+                    <th>신고 대상</th>
+                    <th>신고 사유</th>
+                    <th>신고 시간</th>
+                    <th>처리 시간</th>
+                    <th>처리 상태</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="report : ${list}"
+                    th:onclick="|location.href='/history/reported?filter=product&id=' + ${report.reportId}|"
+                    style="cursor: pointer;">
+                    <td th:text="${report.productName}">상품 이름</td>
+                    <td th:text="${report.reportReason}">사유</td>
+                    <td th:text="${#temporals.format(report.reportDate, 'yyyy-MM-dd HH:mm:ss')}">신고 시간</td>
+                    <td th:text="${report.processedAt != null ? #temporals.format(report.processedAt, 'yyyy-MM-dd HH:mm:ss') : '-'}">처리 시간</td>
+                    <td th:text="${report.status}">상태</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- 유저 신고 리스트 -->
+        <div th:if="${filter=='user'}">
+            <table class="report-table">
+                <thead>
+                <tr>
+                    <th>신고 대상</th>
+                    <th>신고 사유</th>
+                    <th>신고 시간</th>
+                    <th>처리 시간</th>
+                    <th>처리 상태</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="report : ${list}"
+                    th:onclick="|location.href='/history/reported?filter=user&id=' + ${report.reportId}|"
+                    style="cursor: pointer;">
+                    <td th:text="${report.reportedUserName}">신고 대상 유저</td>
+                    <td th:text="${report.reportReason}">사유</td>
+                    <td th:text="${#temporals.format(report.reportDate, 'yyyy-MM-dd HH:mm')}">신고 시간</td>
+                    <td th:text="${report.processedAt != null ? #temporals.format(report.processedAt, 'yyyy-MM-dd HH:mm') : '-'}">처리 시간</td>
+                    <td th:text="${report.status}">상태</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- 페이지네이션 -->
+        <div class="pagination" th:if="${totalPages > 1}">
+            <a th:if="${currentPage > 1}" th:href="@{/history/report(filter=${filter}, page=${currentPage - 1})}">
+                <button>&lt;</button>
+            </a>
+            <span th:each="i : ${#numbers.sequence(1, totalPages)}">
+                <a th:href="@{/history/report(filter=${filter}, page=${i})}">
+                    <button th:text="${i}" th:classappend="${i == currentPage} ? ' active' : ''"></button>
+                </a>
+            </span>
+            <a th:if="${currentPage < totalPages}" th:href="@{/history/report(filter=${filter}, page=${currentPage + 1})}">
+                <button>&gt;</button>
+            </a>
+        </div>
+    </main>
+</div>
+
+<!-- 필터 버튼 전환 스크립트 -->
+<script>
+    function setActiveFilter(selectedButton, tabId) {
+        // 모든 버튼에서 active 클래스를 제거
+        const buttons = document.querySelectorAll(".filter-btn");
+        buttons.forEach(button => {
+            button.classList.remove("active");
+        });
+        // 클릭한 버튼에 active 추가
+        selectedButton.classList.add("active");
+
+        // 모든 탭 숨김
+        const tabContents = document.querySelectorAll(".tab-content");
+        tabContents.forEach(tab => {
+            tab.style.display = "none";
+        });
+        // 선택한 탭 보이기
+        document.getElementById(tabId).style.display = "block";
+    }
+</script>
+
+</body>
+</html>

--- a/src/main/resources/templates/history/reported.html
+++ b/src/main/resources/templates/history/reported.html
@@ -3,110 +3,71 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="layout.html">
 <head>
-    <meta charset="UTF-8">
-    <title>신고 내역</title>
-    <!-- 스타일시트 연결 -->
-    <link rel="stylesheet" href="/css/mypage.css">
-    <link rel="stylesheet" href="/css/reported.css">
+  <meta charset="UTF-8">
+  <title>신고 상세 내역</title>
+  <link rel="stylesheet" href="/css/mypage.css">
+  <style>
+    .card { margin-bottom: 20px; }
+  </style>
 </head>
 <body>
-
-<div class="reported-container" layout:fragment="content">
+<div class="container2" layout:fragment="content">
     <!-- 왼쪽 사이드바 (mypage와 동일) -->
-    <div th:replace="~{mypage/mypage :: sidebar}"></div>
-
-    <!-- 메인 컨텐츠 -->
-    <main class="reported-main">
-        <!-- 페이지 제목 -->
-        <h2>신고 내역</h2>
-
-        <!-- 필터 섹션 -->
-        <div class="filter-section">
-            <div class="filter-buttons">
-                <button class="filter-btn active" onclick="setActiveFilter(this, 'received')">내가 받은 신고</button>
-                <button class="filter-btn" onclick="setActiveFilter(this, 'submitted')">내가 한 신고</button>
-            </div>
+      <div th:replace="~{mypage/mypage :: sidebar}"></div>
+    <!-- 오른쪽 메인 컨텐츠 -->
+    <div class="main2">
+      <h2 class="mb-4">신고 상세 내역</h2>
+      <!-- 신고 내역 카드 -->
+      <div class="card mb-4">
+        <div class="card-header fw-bold">신고 내역</div>
+        <div class="card-body">
+          <!-- 신고 대상: 상품 신고와 유저 신고 구분 -->
+          <div th:if="${reportDetail.type == 'product'}">
+            <p>
+              <strong>신고 대상:</strong>
+              <span th:text="${reportDetail.productName}">상품 이름</span>
+            </p>
+          </div>
+          <div th:if="${reportDetail.type == 'user'}">
+            <p>
+              <strong>신고 대상:</strong>
+              <span th:text="${reportDetail.reportedUserName}">유저 이름</span>
+            </p>
+          </div>
+          <p>
+            <strong>신고 사유:</strong>
+            <span th:text="${reportDetail.reportReason}">신고 사유</span>
+          </p>
+          <p>
+            <strong>신고 내용:</strong>
+          </p>
+          <p th:text="${reportDetail.details}">신고 내용</p>
+          <p>
+            <strong>신고 시간:</strong>
+            <span th:text="${#temporals.format(reportDetail.reportDate, 'yyyy-MM-dd HH:mm')}">신고 시간</span>
+          </p>
         </div>
-
-        <!-- 탭 콘텐츠: 내가 받은 신고 (기본 노출) -->
-        <div class="tab-content" id="received">
-            <table class="reported-table">
-                <thead>
-                <tr>
-                    <th>신고자</th>
-                    <th>신고 사유</th>
-                    <th>신고일</th>
-                    <th>처리 상태</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr onclick="location.href='/report/receivedDetail?id=1'">
-                    <td>홍길동</td>
-                    <td>욕설 및 비방</td>
-                    <td>2025-02-05</td>
-                    <td>처리중</td>
-                </tr>
-                <!-- 추가 행: 백엔드 연동에 따라 동적으로 채워짐 -->
-                </tbody>
-            </table>
+      </div>
+      <!-- 처리 결과 카드 -->
+      <div class="card">
+        <div class="card-header fw-bold">처리 결과</div>
+        <div class="card-body">
+          <p>
+            <strong>처리 상태:</strong>
+            <span th:text="${reportDetail.status}">처리 상태</span>
+          </p>
+          <p>
+            <strong>처리 시간:</strong>
+            <span th:if="${reportDetail.processedAt != null}"
+                  th:text="${#temporals.format(reportDetail.processedAt, 'yyyy-MM-dd HH:mm')}">처리 시간</span>
+            <span th:if="${reportDetail.processedAt == null}"></span>
+          </p>
         </div>
-
-        <!-- 탭 콘텐츠: 내가 신고한 신고 -->
-        <div class="tab-content" id="submitted" style="display: none;">
-            <table class="reported-table">
-                <thead>
-                <tr>
-                    <th>피신고자</th>
-                    <th>신고 사유</th>
-                    <th>신고일</th>
-                    <th>처리 상태</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr onclick="location.href='/report/submittedDetail?id=2'">
-                    <td>김철수</td>
-                    <td>거짓 정보 유포</td>
-                    <td>2025-02-04</td>
-                    <td>완료</td>
-                </tr>
-                <!-- 추가 행: 백엔드 연동에 따라 동적으로 채워짐 -->
-                </tbody>
-            </table>
-        </div>
-
-        <!-- 페이지네이션 -->
-        <div class="pagination">
-            <button><</button>
-            <button class="active">1</button>
-            <button>2</button>
-            <button>3</button>
-            <button>4</button>
-            <button>5</button>
-            <button>></button>
-        </div>
-    </main>
+      </div>
+    </div>
 </div>
-
-<!-- 필터 버튼 전환 스크립트 -->
 <script>
-    function setActiveFilter(selectedButton, tabId) {
-        // 모든 버튼에서 active 클래스를 제거
-        const buttons = document.querySelectorAll(".filter-btn");
-        buttons.forEach(button => {
-            button.classList.remove("active");
-        });
-        // 클릭한 버튼에 active 추가
-        selectedButton.classList.add("active");
 
-        // 모든 탭 숨김
-        const tabContents = document.querySelectorAll(".tab-content");
-        tabContents.forEach(tab => {
-            tab.style.display = "none";
-        });
-        // 선택한 탭 보이기
-        document.getElementById(tabId).style.display = "block";
-    }
 </script>
-
 </body>
 </html>

--- a/src/main/resources/templates/history/sold.html
+++ b/src/main/resources/templates/history/sold.html
@@ -9,10 +9,6 @@
     <link rel="stylesheet" href="/css/mypage.css">
     <script src="/js/smartApiCodes.js"></script>
     <style>
-        .col-md-10 {
-            padding-left: 80px;
-            padding-top: 24px;
-        }
         /* 캐러셀 전체 영역 및 각 슬라이드의 고정 높이 설정 */
         .carousel-inner,
         .carousel-item {
@@ -32,13 +28,12 @@
     </style>
 </head>
 <body>
-<div class="container" layout:fragment="content">
-    <div class="row">
+<div class="container2" layout:fragment="content">
         <!-- 왼쪽 Sidebar (mypage 그대로) -->
         <div class="sidebar" th:replace="~{mypage/mypage :: sidebar}"></div>
         <!-- 오른쪽 메인 컨텐츠 -->
-        <div class="col-md-10">
-            <h2 class="mb-4">판매 내역 상세</h2>
+        <div class="main2">
+            <h2 class="mb-4">판매 상세 내역</h2>
 
             <!-- Section 1: 직거래 및 배송 장소 (Product Info) -->
             <div class="card mb-4">
@@ -116,7 +111,6 @@
             </div>
 
         </div>
-    </div>
 </div>
 
 <!-- 배송 운송장 등록 모달 HTML -->

--- a/src/main/resources/templates/mypage/mypage.html
+++ b/src/main/resources/templates/mypage/mypage.html
@@ -25,12 +25,12 @@
             <!-- 사용자 정보 관련 메뉴 -->
             <h3>MY SSAUC</h3>
             <ul>
-                <li><a href="#">나의 신뢰도</a></li>
                 <li><a th:href="@{#}">회원 정보 수정</a></li>
-                <li><a th:href="@{/history/reported}">신고 내역 조회</a></li>
-                <li><a th:href="@{/history/ban}">차단 내역 조회</a></li>
-                <li><a th:href="@{#}">관심 상품 목록</a></li>
+                <li><a th:href="@{/mypage/evaluation}">나의 신뢰도</a></li>
                 <li><a th:href="@{#}">채팅 목록</a></li>
+                <li><a th:href="@{/history/ban}">차단 내역 조회</a></li>
+                <li><a th:href="@{/history/report}">신고 내역 조회</a></li>
+                <li><a th:href="@{/list/likelist}">관심 상품 목록</a></li>
             </ul>
             <!-- 거래 관련 메뉴 -->
             <h3>나의 거래 정보</h3>
@@ -42,9 +42,9 @@
             <!-- 고객 지원 관련 메뉴 -->
             <h3>고객센터</h3>
             <ul>
-                <li><a th:href="@{#}">자주 묻는 질문</a></li>
-                <li><a th:href="@{#}">1:1 문의하기</a></li>
-                <li><a th:href="@{#}">챗봇 상담</a></li>
+                <li><a th:href="@{/contact/chatbot}">챗봇 상담</a></li>
+                <li><a th:href="@{/contact/qna}">1:1 문의하기</a></li>
+                <li><a th:href="@{/contact/faq}">자주 묻는 질문</a></li>
             </ul>
         </nav>
     </aside>


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 작업 내용 입력 -->
- 신고 내역
  - 신고 리스트
    - 신고 내역 페이지에서 "상품 신고"와 "유저 신고" 필터를 제공
    - 각 필터에 따라 ProductReport(상품 신고) 또는 Report(유저 신고) 데이터를 조회
    - 각 리스트 항목은 클릭 시 신고 상세 페이지로 이동하도록 구현
      - 이동 시 URL에 신고 유형(filter)과 신고 id(reportId)를 함께 전달하여 올바른 상세 정보를 조회하도록 함
  - 신고 상세 내역
    - 신고 상세 페이지는 URL 파라미터로 전달된 신고 유형(filter)과 신고 id(id)를 기반으로 데이터를 조회
    - 신고 유형에 따라 먼저 ProductReport 테이블에서 조회하고, 없으면 Report 테이블에서 조회
    - 조회된 데이터는 ReportDetailDto에 매핑되어 reported.html에서 조건부 렌더링(상품 신고와 유저 신고 구분)으로 표시됨

- html 수정
  - 마이페이지 사이드바에 다른 팀원 구현 사항 연결
## 📎 Issue 번호
<!-- closed #번호 -->
#144 