### PR TITLE
사용자 Reputation 기능 구현

### DIFF
--- a/src/main/java/com/example/ssauc/user/login/entity/Users.java
+++ b/src/main/java/com/example/ssauc/user/login/entity/Users.java
@@ -92,7 +92,7 @@ public class Users {
             this.status = "active";
         }
         if (this.reputation == null) {
-            this.reputation = 50.0;
+            this.reputation = 30.0;
         }
         if (this.cash == null) {
             this.cash = 0L;

--- a/src/main/java/com/example/ssauc/user/login/repository/UsersRepository.java
+++ b/src/main/java/com/example/ssauc/user/login/repository/UsersRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
@@ -35,6 +37,6 @@ public interface UsersRepository extends JpaRepository<Users, Long> {
   boolean existsByUserName(String userName);
   boolean existsByPhone(String phone);
 
-
+  List<Users> findByLastLoginBefore(LocalDateTime date);
 
 }

--- a/src/main/java/com/example/ssauc/user/login/service/UserService.java
+++ b/src/main/java/com/example/ssauc/user/login/service/UserService.java
@@ -75,6 +75,11 @@ public class UserService {
             log.info("사용자 조회 성공: {}", normalizedEmail);
             if (passwordEncoder.matches(password, user.getPassword())) {
                 log.info("비밀번호 일치함: {}", normalizedEmail);
+
+                // lastLogin 업데이트
+                user.updateLastLogin();
+                userRepository.save(user);
+
                 String accessToken = jwtUtil.generateAccessToken(normalizedEmail);
                 String refreshToken = jwtUtil.generateRefreshToken(normalizedEmail);
                 log.info("생성된 Access Token: {}", accessToken);

--- a/src/main/java/com/example/ssauc/user/mypage/controller/MypageController.java
+++ b/src/main/java/com/example/ssauc/user/mypage/controller/MypageController.java
@@ -126,6 +126,15 @@ public class MypageController {
         EvaluatedDto reviewDto = mypageService.getReviewById(reviewId, latestUser.getUserId());
         model.addAttribute("review", reviewDto);
 
+        // reviewType 결정: 현재 사용자가 리뷰 작성자이면 "written", 아니면 "received"
+        String reviewType = "";
+        if(latestUser.getUserName().equals(reviewDto.getReviewerName())) {
+            reviewType = "written";
+        } else {
+            reviewType = "received";
+        }
+        model.addAttribute("reviewType", reviewType);
+
         return "/mypage/evaluated";
     }
 

--- a/src/main/java/com/example/ssauc/user/mypage/dto/EvaluationReviewDto.java
+++ b/src/main/java/com/example/ssauc/user/mypage/dto/EvaluationReviewDto.java
@@ -16,8 +16,10 @@ public class EvaluationReviewDto { // 작성된 리뷰 리스트
     // 리뷰 대상:
     // - written: 리뷰 작성 시 대상은 review.getReviewee()의 이름
     // - received: 리뷰 수신 시 대상은 review.getReviewer()의 이름
-    private String reviewTarget;
-    private String profileImageUrl;
+    private String reviewer;
+    private String reviewee;
+    private String profileImageUrl1;
+    private String profileImageUrl2;
     // 주문한 상품의 이름 (orders → product)
     private Long productId;
     private String productName;

--- a/src/main/java/com/example/ssauc/user/mypage/event/OrderCompletedEvent.java
+++ b/src/main/java/com/example/ssauc/user/mypage/event/OrderCompletedEvent.java
@@ -1,0 +1,22 @@
+package com.example.ssauc.user.mypage.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import java.time.LocalDateTime;
+
+@Getter
+public class OrderCompletedEvent extends ApplicationEvent {
+    // 거래(판매 및 구매) 완료 이벤트: reputation +1.0
+    // 한 달에 거래 3회 이상 이벤트: reputation +3.0
+
+    private final Long buyerId;
+    private final Long sellerId;
+    private final LocalDateTime completedAt;
+
+    public OrderCompletedEvent(Object source, Long buyerId, Long sellerId, LocalDateTime completedAt) {
+        super(source);
+        this.buyerId = buyerId;
+        this.sellerId = sellerId;
+        this.completedAt = completedAt;
+    }
+}

--- a/src/main/java/com/example/ssauc/user/mypage/event/OrderShippedEvent.java
+++ b/src/main/java/com/example/ssauc/user/mypage/event/OrderShippedEvent.java
@@ -1,0 +1,21 @@
+package com.example.ssauc.user.mypage.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import java.time.LocalDateTime;
+
+@Getter
+public class OrderShippedEvent extends ApplicationEvent {
+    // 운송장 정보 등록 이벤트(주문 후 24시간 이내): reputation +1.0
+
+    private final Long sellerId;
+    private final LocalDateTime orderDate;
+    private final LocalDateTime shippedDate;
+
+    public OrderShippedEvent(Object source, Long sellerId, LocalDateTime orderDate, LocalDateTime shippedDate) {
+        super(source);
+        this.sellerId = sellerId;
+        this.orderDate = orderDate;
+        this.shippedDate = shippedDate;
+    }
+}

--- a/src/main/java/com/example/ssauc/user/mypage/event/ReputationEventListener.java
+++ b/src/main/java/com/example/ssauc/user/mypage/event/ReputationEventListener.java
@@ -1,0 +1,48 @@
+package com.example.ssauc.user.mypage.event;
+
+import com.example.ssauc.user.mypage.service.ReputationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class ReputationEventListener {
+    // 이벤트 리스너
+
+    private final ReputationService reputationService;
+
+    // 거래 완료 처리
+    @EventListener
+    public void handleOrderCompleted(OrderCompletedEvent event) {
+        reputationService.updateReputationForOrder(event.getBuyerId(), "구매 완료", 1.0);
+        reputationService.updateReputationForOrder(event.getSellerId(), "판매 완료", 1.0);
+    }
+
+    // 운송장 등록 이벤트 처리: 주문일로부터 24시간 이내라면 +1.0점
+    @EventListener
+    public void handleOrderShipped(OrderShippedEvent event) {
+        Duration diff = Duration.between(event.getOrderDate(), event.getShippedDate());
+        if(diff.toHours() < 24) {
+            reputationService.updateReputation(event.getSellerId(), "24시간 내 운송장 등록", 1.0);
+        }
+    }
+
+    // 신고 경고 이벤트 처리: -5.0점 적용
+    @EventListener
+    public void handleUserWarned(UserWarnedEvent event) {
+        reputationService.updateReputation(event.getReportedUserId(), "신고 경고 처리", -5.0);
+    }
+
+    // 리뷰 등록 이벤트 처리:
+    // 리뷰 작성자: reputation +0.5
+    // 리뷰 대상자: reputation +baseScore(-1.5 ~ 1.5)
+    @EventListener
+    public void handleReviewSubmitted(ReviewSubmittedEvent event) {
+        // 리뷰어는 리뷰 작성 시 +0.5점
+        reputationService.updateReputation(event.getReviewerId(), "리뷰 작성", 0.5);
+        // 리뷰 대상은 받은 거래 후기의 baseScore 만큼 평판 변경 (긍정/부정 옵션에 따라 각각 +0.5 또는 -0.5)
+        reputationService.updateReputation(event.getRevieweeId(), "받은 거래 후기", event.getBaseScore());
+    }
+}

--- a/src/main/java/com/example/ssauc/user/mypage/event/ReviewSubmittedEvent.java
+++ b/src/main/java/com/example/ssauc/user/mypage/event/ReviewSubmittedEvent.java
@@ -1,0 +1,24 @@
+package com.example.ssauc.user.mypage.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import java.time.LocalDateTime;
+
+@Getter
+public class ReviewSubmittedEvent extends ApplicationEvent {
+    // 리뷰 작성자: reputation +0.5
+    // 리뷰 대상자: reputation +baseScore(-1.5 ~ 1.5)
+
+    private final Long reviewerId;
+    private final Long revieweeId;
+    private final double baseScore;
+    private final LocalDateTime createdAt;
+
+    public ReviewSubmittedEvent(Object source, Long reviewerId, Long revieweeId, double baseScore, LocalDateTime createdAt) {
+        super(source);
+        this.reviewerId = reviewerId;
+        this.revieweeId = revieweeId;
+        this.baseScore = baseScore;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/example/ssauc/user/mypage/event/UserWarnedEvent.java
+++ b/src/main/java/com/example/ssauc/user/mypage/event/UserWarnedEvent.java
@@ -1,0 +1,16 @@
+package com.example.ssauc.user.mypage.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class UserWarnedEvent extends ApplicationEvent {
+    // 유저 및 상품 신고에 대한 관리자의 경고 처리 이벤트: reputation -5.0
+
+    private final Long reportedUserId;
+
+    public UserWarnedEvent(Object source, Long reportedUserId) {
+        super(source);
+        this.reportedUserId = reportedUserId;
+    }
+}

--- a/src/main/java/com/example/ssauc/user/mypage/repository/ReputationHistoryRepository.java
+++ b/src/main/java/com/example/ssauc/user/mypage/repository/ReputationHistoryRepository.java
@@ -1,7 +1,15 @@
 package com.example.ssauc.user.mypage.repository;
 
+import com.example.ssauc.user.login.entity.Users;
 import com.example.ssauc.user.mypage.entity.ReputationHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReputationHistoryRepository extends JpaRepository<ReputationHistory, Long> {
+    // 특정 사용자의 평판 기록이 있는지 확인하는 메서드 추가
+    boolean existsByUser(Users user);
+
+    // 특정 사용자의 평판 변화 이력을 조회 (중복 계산 방지용)
+    List<ReputationHistory> findByUserAndChangeTypeNotLike(Users user, String pattern);
 }

--- a/src/main/java/com/example/ssauc/user/mypage/repository/UserActivityRepository.java
+++ b/src/main/java/com/example/ssauc/user/mypage/repository/UserActivityRepository.java
@@ -1,7 +1,11 @@
 package com.example.ssauc.user.mypage.repository;
 
+import com.example.ssauc.user.login.entity.Users;
 import com.example.ssauc.user.mypage.entity.UserActivity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserActivityRepository extends JpaRepository<UserActivity, Long> {
+    Optional<UserActivity> findByUser(Users user);
 }

--- a/src/main/java/com/example/ssauc/user/mypage/scheduler/InactivityPenaltyScheduler.java
+++ b/src/main/java/com/example/ssauc/user/mypage/scheduler/InactivityPenaltyScheduler.java
@@ -1,0 +1,57 @@
+package com.example.ssauc.user.mypage.scheduler;
+
+import com.example.ssauc.user.login.entity.Users;
+import com.example.ssauc.user.login.repository.UsersRepository;
+import com.example.ssauc.user.mypage.entity.ReputationHistory;
+import com.example.ssauc.user.mypage.repository.ReputationHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class InactivityPenaltyScheduler {
+    // 장기 미접속 유저 reputation 감소
+
+    private final UsersRepository usersRepository;
+    private final ReputationHistoryRepository reputationHistoryRepository;
+
+    // 매월 1일 00:00에 실행하도록 스케줄러 설정
+    @Scheduled(cron = "0 0 0 1 * ?")
+    public void applyInactivityPenalty() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime threeMonthsAgo = now.minusMonths(3);
+
+        // lastLogin이 3개월 이전인 사용자들 조회
+        List<Users> inactiveUsers = usersRepository.findByLastLoginBefore(threeMonthsAgo);
+
+        for (Users user : inactiveUsers) {
+            // 미접속 개월 수 계산 (예: 5개월 미접속이면, penaltyMonths = 5 - 3 = 2)
+            long monthsInactive = ChronoUnit.MONTHS.between(user.getLastLogin(), now);
+            long penaltyMonths = Math.max(monthsInactive - 3, 0);
+
+            // 매월 -3%씩, 최대 -36%까지
+            double penaltyRate = Math.min(penaltyMonths * 0.03, 0.36);
+            double penaltyAmount = user.getReputation() * penaltyRate;
+            double newReputation = user.getReputation() - penaltyAmount;
+
+            // 사용자 평판 업데이트
+            user.setReputation(newReputation);
+            usersRepository.save(user);
+
+            // 평판 변경 이력 기록
+            ReputationHistory history = ReputationHistory.builder()
+                    .user(user)
+                    .changeType("3개월 이상 미접속 패널티")
+                    .changeAmount(-penaltyAmount)
+                    .newScore(newReputation)
+                    .createdAt(now)
+                    .build();
+            reputationHistoryRepository.save(history);
+        }
+    }
+}

--- a/src/main/java/com/example/ssauc/user/mypage/scheduler/MonthlyTradeResetScheduler.java
+++ b/src/main/java/com/example/ssauc/user/mypage/scheduler/MonthlyTradeResetScheduler.java
@@ -1,0 +1,28 @@
+package com.example.ssauc.user.mypage.scheduler;
+
+import com.example.ssauc.user.mypage.repository.UserActivityRepository;
+import com.example.ssauc.user.mypage.entity.UserActivity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyTradeResetScheduler {
+    // 월별 거래 횟수 초기화
+
+    private final UserActivityRepository userActivityRepository;
+
+    // 매월 1일 00:00에 모든 유저의 monthly_trade_count를 초기화
+    @Scheduled(cron = "0 0 0 1 * ?")
+    public void resetMonthlyTradeCounts() {
+        List<UserActivity> activities = userActivityRepository.findAll();
+        for (UserActivity activity : activities) {
+            activity.setMonthlyTradeCount(0L);
+            activity.setLastUpdated(LocalDateTime.now());
+        }
+        userActivityRepository.saveAll(activities);
+    }
+}

--- a/src/main/java/com/example/ssauc/user/mypage/scheduler/ReputationRecalculationScheduler.java
+++ b/src/main/java/com/example/ssauc/user/mypage/scheduler/ReputationRecalculationScheduler.java
@@ -1,0 +1,97 @@
+package com.example.ssauc.user.mypage.scheduler;
+
+import com.example.ssauc.user.login.entity.Users;
+import com.example.ssauc.user.login.repository.UsersRepository;
+import com.example.ssauc.user.mypage.entity.ReputationHistory;
+import com.example.ssauc.user.mypage.repository.ReputationHistoryRepository;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Component
+@RequiredArgsConstructor
+public class ReputationRecalculationScheduler {
+
+    private final UsersRepository usersRepository;
+    private final ReputationHistoryRepository reputationHistoryRepository;
+
+    // 하루 1회
+    @Scheduled(cron = "0 0 4 * * ?")
+    public void recalculateReputations() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 모든 사용자 조회
+        List<Users> users = usersRepository.findAll();
+
+        for (Users user : users) {
+            // 원본 평판 기록이 없다면 스킵
+            if (!reputationHistoryRepository.existsByUser(user)) {
+                continue;
+            }
+
+            // "가중치 적용" 패턴이 포함되지 않은 평판 변화 내역 조회
+            List<ReputationHistory> histories =
+                    reputationHistoryRepository.findByUserAndChangeTypeNotLike(user, "%가중치 적용%");
+
+            for (ReputationHistory history : histories) {
+                long days = ChronoUnit.DAYS.between(history.getCreatedAt(), now);
+
+                // 3개월, 6개월, 12개월 조건에 맞춰 "단계별 추가 차감" 적용
+                if (days >= 90 && days < 91) {
+                    applyPartialReduction(user, history, new BigDecimal("0.1"), "3개월 가중치 적용", now);
+                } else if (days >= 180 && days < 181) {
+                    applyPartialReduction(user, history, new BigDecimal("0.2"), "6개월 가중치 적용", now);
+                } else if (days >= 365 && days < 366) {
+                    applyPartialReduction(user, history, new BigDecimal("0.2"), "12개월 가중치 적용", now);
+                }
+            }
+        }
+    }
+
+    // 기간 별 차감 정도 계산
+    // @param fraction: 원본 점수 대비 차감 비율 (예: 0.1, 0.2)
+    private void applyPartialReduction(Users user, ReputationHistory history,
+                                       BigDecimal fraction, String changeType, LocalDateTime now) {
+        // 원본 점수를 BigDecimal로 변환 후 소숫점 1자리 반올림
+        BigDecimal original = BigDecimal.valueOf(history.getChangeAmount())
+                .setScale(1, RoundingMode.HALF_UP);
+
+        // 차감할 양: 원본 * fraction, 소숫점 1자리 반올림
+        BigDecimal reductionBD = original.multiply(fraction)
+                .setScale(1, RoundingMode.HALF_UP);
+
+        // 현재 평판을 BigDecimal로 변환 후 소숫점 1자리 반올림
+        BigDecimal currentReputation = BigDecimal.valueOf(user.getReputation())
+                .setScale(1, RoundingMode.HALF_UP);
+
+        // 새 평판 = 현재 평판 - 차감량, 음수면 0으로 처리하고 반올림
+        BigDecimal newReputation = currentReputation.subtract(reductionBD)
+                .max(BigDecimal.ZERO)
+                .setScale(1, RoundingMode.HALF_UP);
+
+        // 사용자 평판 업데이트 (DB 필드가 double인 경우 doubleValue() 사용)
+        user.setReputation(newReputation.doubleValue());
+        usersRepository.save(user);
+
+
+        // 적용된 가중치 대상 history_id를 changeType 앞에 추가
+        String updatedChangeType = history.getHistoryId() + " - " + changeType;
+
+        // 감소량이 있을 경우 기록
+        if (reductionBD.compareTo(BigDecimal.ZERO) > 0) {
+            ReputationHistory partialRecord = ReputationHistory.builder()
+                    .user(user)
+                    .changeType(updatedChangeType) // 원본과 구분하기 위해 고정
+                    .changeAmount(-reductionBD.doubleValue())
+                    .newScore(newReputation.doubleValue())
+                    .createdAt(now)
+                    .build();
+            reputationHistoryRepository.save(partialRecord);
+        }
+    }
+}

--- a/src/main/java/com/example/ssauc/user/mypage/service/ReputationService.java
+++ b/src/main/java/com/example/ssauc/user/mypage/service/ReputationService.java
@@ -1,0 +1,14 @@
+package com.example.ssauc.user.mypage.service;
+
+import com.example.ssauc.user.login.entity.Users;
+
+
+public interface ReputationService {
+    // 평판 관련 로직 담당
+
+    Users getCurrentUser(String email);
+
+    void updateReputation(Long userId, String changeType, double changeAmount);
+
+    void updateReputationForOrder(Long userId, String changeType, double changeAmount);
+}

--- a/src/main/java/com/example/ssauc/user/mypage/service/ReputationServiceImpl.java
+++ b/src/main/java/com/example/ssauc/user/mypage/service/ReputationServiceImpl.java
@@ -1,0 +1,100 @@
+package com.example.ssauc.user.mypage.service;
+
+import com.example.ssauc.common.service.CommonUserService;
+import com.example.ssauc.user.login.entity.Users;
+import com.example.ssauc.user.login.repository.UsersRepository;
+import com.example.ssauc.user.mypage.entity.ReputationHistory;
+import com.example.ssauc.user.mypage.entity.UserActivity;
+import com.example.ssauc.user.mypage.repository.ReputationHistoryRepository;
+import com.example.ssauc.user.mypage.repository.UserActivityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ReputationServiceImpl implements ReputationService {
+
+    private final CommonUserService commonUserService;
+    private final UsersRepository userRepository;
+    private final ReputationHistoryRepository reputationHistoryRepository;
+    private final UserActivityRepository userActivityRepository;
+
+    @Override
+    public Users getCurrentUser(String email) {
+        return commonUserService.getCurrentUser(email);
+    }
+
+    @Transactional
+    public void updateReputation(Long userId, String changeType, double changeAmount) {
+        Users user = getUserById(userId);
+
+        // 기존 평판 업데이트
+        double newReputation = applyReputationChange(user, changeAmount);
+
+        // 평판 변경 이력 기록
+        saveReputationHistory(user, changeType, changeAmount, newReputation);
+    }
+
+    @Transactional
+    public void updateReputationForOrder(Long userId, String changeType, double changeAmount) {
+        Users user = getUserById(userId);
+
+        // 기존 평판 업데이트
+        double newReputation = applyReputationChange(user, changeAmount);
+
+        // 평판 변경 이력 기록
+        saveReputationHistory(user, changeType, changeAmount, newReputation);
+
+        // 거래 횟수 증가 및 월간 보너스 체크
+        updateUserTradeCountAndBonus(user);
+    }
+
+    private Users getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+    }
+
+    // 기존 평판 업데이트
+    private double applyReputationChange(Users user, double changeAmount) {
+        double newReputation = user.getReputation() + changeAmount;
+        user.setReputation(newReputation);
+        userRepository.save(user);
+        return newReputation;
+    }
+
+    // 평판 변경 이력 기록
+    private void saveReputationHistory(Users user, String changeType, double changeAmount, double newReputation) {
+        ReputationHistory history = ReputationHistory.builder()
+                .user(user)
+                .changeType(changeType)
+                .changeAmount(changeAmount)
+                .newScore(newReputation)
+                .createdAt(LocalDateTime.now())
+                .build();
+        // 거래 횟수 증가 및 월간 보너스 체크
+        reputationHistoryRepository.save(history);
+    }
+
+    private void updateUserTradeCountAndBonus(Users user) {
+        UserActivity activity = userActivityRepository.findByUser(user)
+                .orElse(UserActivity.builder()
+                        .user(user)
+                        .monthlyTradeCount(0L)
+                        .lastUpdated(LocalDateTime.now())
+                        .build());
+
+        long newCount = activity.getMonthlyTradeCount() + 1;
+        activity.setMonthlyTradeCount(newCount);
+        activity.setLastUpdated(LocalDateTime.now());
+        userActivityRepository.save(activity);
+
+        // 월간 보너스 적용 (거래 횟수가 3이 되는 순간)
+        if (newCount == 3) {
+            updateReputation(user.getUserId(), "월간 거래 보너스", 3.0);
+        }
+    }
+
+
+}

--- a/src/main/resources/templates/mypage/evaluated.html
+++ b/src/main/resources/templates/mypage/evaluated.html
@@ -43,20 +43,22 @@
                 </div>
                 <div class="rating-item">
                     <span class="rating-label"
-                          th:text="${review.transactionType == '구매' ? '상품 상태:' : '가격 협상 과정:'}">
+                          th:text="${#strings.equals(reviewType, 'written') ? (review.transactionType == '구매' ? '상품 상태:' : '가격 협상 과정:') : (review.transactionType == '구매' ? '가격 협상 과정:' : '상품 상태:')}">
                     </span>
                     <span class="rating-value"
                           th:classappend="${review.option2} ? ' positive' : ' negative'"
-                          th:text="${review.transactionType == '구매' ? (review.option2 ? '✨ 마음에 들어요' : '💔 설명과 달라요') : (review.option2 ? '😍 깔끔한 거래' : '🥶 무리한 요청')}">
+                          th:text="${#strings.equals(reviewType, 'written') ? (review.transactionType == '구매' ? (review.option2 ? '✨ 마음에 들어요' : '💔 설명과 달라요') : (review.option2 ? '😍 깔끔한 거래' : '🥶 무리한 요청'))
+                                      : (review.transactionType == '구매' ? (review.option2 ? '😍 깔끔한 거래' : '🥶 무리한 요청') : (review.option2 ? '✨ 마음에 들어요' : '💔 설명과 달라요'))}">
                     </span>
                 </div>
                 <div class="rating-item">
                     <span class="rating-label"
-                          th:text="${review.transactionType == '구매' ? '가격:' : '상품 수령 후 피드백:'}">
+                          th:text="${#strings.equals(reviewType, 'written') ? (review.transactionType == '구매' ? '가격:' : '상품 수령 후 피드백:') : (review.transactionType == '구매' ? '상품 수령 후 피드백:' : '가격:')}">
                     </span>
                     <span class="rating-value"
                           th:classappend="${review.option3} ? ' positive' : ' negative'"
-                          th:text="${review.transactionType == '구매' ? (review.option3 ? '🤩 합리적이에요' : '🤑 비쌌어요') : (review.option3 ? '💬 빠른 피드백' : '🚫 연락 두절')}">
+                          th:text="${#strings.equals(reviewType, 'written') ? (review.transactionType == '구매' ? (review.option3 ? '🤩 합리적이에요' : '🤑 비쌌어요') : (review.option3 ? '💬 빠른 피드백' : '🚫 연락 두절'))
+                                      : (review.transactionType == '구매' ? (review.option3 ? '💬 빠른 피드백' : '🚫 연락 두절') : (review.option3 ? '🤩 합리적이에요' : '🤑 비쌌어요'))}">
                     </span>
                 </div>
             </div>

--- a/src/main/resources/templates/mypage/evaluation.html
+++ b/src/main/resources/templates/mypage/evaluation.html
@@ -89,8 +89,8 @@
                 <tr th:each="review : ${reviewList}"
                     th:with="urlPrefix=${review.transactionType.trim() == '구매' ? '/history/bought?id=' : '/history/sold?id='}">
                     <td>
-                        <img class="historyImage" th:src="${review.profileImageUrl}" alt="프로필 이미지"/>
-                        <span th:text="${review.reviewTarget}">user</span>
+                        <img class="historyImage" th:src="${review.profileImageUrl1}" alt="프로필 이미지"/>
+                        <span th:text="${review.reviewer}">user</span>
                     </td>
                     <td>
                         <img class="historyImage" th:src="${review.productImageUrl}" alt="상품 이미지"/>
@@ -126,8 +126,8 @@
                 <tr th:each="review : ${reviewList}"
                     th:with="urlPrefix=${review.transactionType.trim() == '구매' ? '/history/bought?id=' : '/history/sold?id='}">
                     <td>
-                        <img class="historyImage" th:src="${review.profileImageUrl}" alt="프로필 이미지"/>
-                        <span th:text="${review.reviewTarget}">user</span>
+                        <img class="historyImage" th:src="${review.profileImageUrl2}" alt="프로필 이미지"/>
+                        <span th:text="${review.reviewee}">user</span>
                     </td>
                     <td>
                         <img class="historyImage" th:src="${review.productImageUrl}" alt="상품 이미지"/>


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 작업 내용 입력 -->
1. 평판 점수 상승 항목

  - 거래 성공 (구매/판매 완료):
    - 거래 성공 시 +1.0점 증가
  - 리뷰 작성:
    - 리뷰 작성 시 +0.5점 증가
  - 긍정적인 거래 후기:
    - 항목 당 +0.5점 증가
  - 주문 24시간 이내 운송장 등록:
    - 등록 시 +1.0점 증가
  - 최근 30일 내 3건 이상 거래 (구매 또는 판매, 월 1회 한정):
    - 조건 만족 시 +3.0점 증가

2. 평판 점수 하락 항목

  - 부정적인 거래 후기:
    - 항목 당 -0.5점 감소
  - 당한 신고에 대해 관리자가 확인한 경우:
    - 확인 시 -5.0점 감소
  - 3개월 이상 미접속 시:
    - 이후 매월 **-3%**씩 감소하며 최대 **-36%**까지 자동 차감

3. 시간 가중치 적용
평가가 진행된 시점에 따라 가중치를 달리 적용하여, 최신 거래 활동이 더 크게 반영되도록 구현


최근 3개월 내 평가: 1.0배
3~6개월 전 평가: 0.9배
6~12개월 전 평가: 0.7배
12개월 이상 지난 평가: 0.5배

4. 스케줄러 및 평판 이력 관리
  
  - 동작 방식:
    - 모든 사용자를 대상으로 평판 이력을 조회
    - 평판 이력 중 "가중치 적용" 패턴이 없는 항목들만 대상으로 처리
    - ChronoUnit.DAYS.between(history.getCreatedAt(), now) 를 사용하여 경과일 계산 후 아래 조건에 맞춰 추가 차감 적용
    - 90일(3개월): 원본 점수의 10% 차감 
    - 180일(6개월): 원본 점수의 20% 차감 
    - 365일(12개월): 원본 점수의 20% 차감 
    - 평판 점수 계산 시 BigDecimal을 사용해 소숫점 1자리 반올림 처리

  - 평판 이력 기록:
    - 차감 적용 시 ReputationHistory 엔티티에 새로운 이력으로 저장
    - 이력의 changeType에 기존 historyId와 가중치 적용 정보를 함께 기록
    - 중복 적용을 피하기 위해 평판 이력의 생성일(createdAt)과 현재 시간의 차이를 기준으로 정확한 조건(예: 90일, 180일, 365일)에만 가중치가 적용되도록 구현 


## 📎 Issue 번호
<!-- closed #번호 -->
#212 